### PR TITLE
NoSuchMethod raised up to HighLine.ask when ctrl-D is pressed in readline mode

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -591,9 +591,16 @@ class HighLine
       # work-around ugly readline() warnings
       old_verbose = $VERBOSE
       $VERBOSE    = nil
+      raw_answer  = Readline.readline(question, true)
+      if raw_answer.nil?
+        if @@track_eof
+          raise EOFError, "The input stream is exhausted."
+        else
+          raw_answer = String.new # Never return nil
+        end
+      end
       answer      = @question.change_case(
-                        @question.remove_whitespace(
-                            Readline.readline(question, true) ) )
+                        @question.remove_whitespace(raw_answer))
       $VERBOSE    = old_verbose
 
       answer


### PR DESCRIPTION
Found this while using HighLine in readline mode.  If ctrl-D is pressed in the terminal with no input preceding it on the line, readline interprets this as an EOF (as it should) and returns nil.  HighLine then tries to remove whitespace, etc which fails because it's expecting a string back. 

Proposed fix handles catching the nil and uses the existing track_eof flag to decide whether to raise the EOFError up or interpret it as a blank string (in my case, i want it raised up so that I can exit the program on ctrl-d). 
