### PR TITLE
Loading crtdll fails

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -35,7 +35,7 @@ class HighLine
       # character from +STDIN+!
       # 
       def get_character( input = STDIN )
-        Win32API.new("crtdll", "_getch", [ ], "L").Call
+        Win32API.new("msvcrt", "_getch", [ ], "L").Call
       end
 
       # A Windows savvy method to fetch the console columns, and rows.


### PR DESCRIPTION
Hi James,

On my windows 7 installation loading crtdll failed for some reason. I changed system_extensions.rb to load msvcrt instead and that does work as it's supposed to.
The patch is messed due to newline encoding differences I think, sorry about that. The only change is on line 38 where
Win32API.new("crtdll", "_getch", [ ], "L").Call
is replaced by
Win32API.new("msvcrt", "_getch", [ ], "L").Call
