### PR TITLE
Handle empty items consistently in HighLine#list

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -428,12 +428,9 @@ class HighLine
       case mode
       when :inline
         option = " or " if option.nil?
-      
-        case items.size
-        when 1
+        
+        if items.size == 1
           items.first
-        when 2
-          "#{items.first}#{option}#{items.last}"
         else
           items[0..-2].join(", ") + "#{option}#{items.last}"
         end

--- a/test/tc_highline.rb
+++ b/test/tc_highline.rb
@@ -458,11 +458,53 @@ class TestHighLine < Test::Unit::TestCase
                   
   end
   
-  def test_lists_with_empty_items
-    modes = [nil, :inline, :columns_across, :columns_down]
+  def test_lists_with_zero_items
+    modes = [nil, :rows, :inline, :columns_across, :columns_down]
     modes.each do |mode|
       result = @terminal.list([], mode)
       assert_equal("", result)
+    end
+  end
+  
+  def test_lists_with_one_item
+    items = ['Zero']
+    modes = { nil            => "Zero\n",
+             :rows           => "Zero\n",
+             :inline         => "Zero",
+             :columns_across => "Zero\n",
+             :columns_down   => "Zero\n" }
+             
+    modes.each do |mode, expected|
+      result = @terminal.list(items, mode)
+      assert_equal(expected, result)
+    end
+  end
+  
+  def test_lists_with_two_items
+    items = ['Zero', 'One']
+    modes = { nil            => "Zero\nOne\n",
+             :rows           => "Zero\nOne\n",
+             :inline         => "Zero or One",
+             :columns_across => "Zero  One \n",
+             :columns_down   => "Zero  One \n" }
+             
+    modes.each do |mode, expected|
+      result = @terminal.list(items, mode)
+      assert_equal(expected, result)
+    end
+  end
+  
+  def test_lists_with_three_items
+    items = ['Zero', 'One', 'Two']
+    modes = { nil            => "Zero\nOne\nTwo\n",
+             :rows           => "Zero\nOne\nTwo\n",
+             :inline         => "Zero, One or Two",
+             :columns_across => "Zero  One   Two \n",
+             :columns_down   => "Zero  One   Two \n" }
+
+    modes.each do |mode, expected|
+      result = @terminal.list(items, mode)
+      assert_equal(expected, result)
     end
   end
   


### PR DESCRIPTION
Without this patch HighLine#list throws an error when called with an
empty items array and a :columns_across or :columns_down mode. For
example HighLine.new.list([], :columns_across) results in:

  NoMethodError: private method `gsub' called for nil:NilClass
    actual_length at .../highline-1.6.2/lib/highline.rb:761
             list at .../highline-1.6.2/lib/highline.rb:394

This patch fixes this error so that HighLine#list always returns an
empty string when called with an empty items array, regardless of mode.
