### PR TITLE
Correct mistaken argument to HighLine.Style() from 'erase_line' to :erase_line

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -820,7 +820,7 @@ class HighLine
           restore_mode if stty
         end
         if @question.overwrite
-          @output.print("\r#{HighLine.Style('erase_line').code}")
+          @output.print("\r#{HighLine.Style(:erase_line).code}")
           @output.flush
         else
           say("\n")
@@ -833,7 +833,7 @@ class HighLine
     else
       response = get_character(@input).chr
       if @question.overwrite
-        @output.print("\r#{HighLine.Style('erase_line').code}")
+        @output.print("\r#{HighLine.Style(:erase_line).code}")
         @output.flush
       else
         echo = if @question.echo == true


### PR DESCRIPTION
Fixed argument type to HighLine.Style().  Changed from string to symbol.  My mistake.
