### PR TITLE
Termios doesnt work

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -100,9 +100,9 @@ class HighLine
           #
           def get_character( input = STDIN )
             FFI::NCurses.initscr
+            FFI::NCurses.cbreak
             begin
-              FFI::NCurses.cbreak
-              FFI::NCurses.noecho
+              FFI::NCurses.curs_set 0
               input.getbyte
             ensure
               FFI::NCurses.endwin


### PR DESCRIPTION
Even in Ruby reading characters via termios doesn't work because an explicit raise LoadError prevents it from reaching the code.
