### PR TITLE
Explicit raise prevents plain ruby from ever using termios

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -61,7 +61,6 @@ class HighLine
       end
     rescue LoadError                  # If we're not on Windows try...
       begin
-        raise LoadError
         require "termios"             # Unix, first choice termios.
 
         CHARACTER_MODE = "termios"    # For Debugging purposes only.


### PR DESCRIPTION
When using plain Ruby, reading characters via termios doesn't work because an explicit raise LoadError prevents it from reaching the relevant code.
