### PR TITLE
Feature: Typing verification using multiple matching entries

### DIFF
--- a/examples/repeat_entry.rb
+++ b/examples/repeat_entry.rb
@@ -1,0 +1,21 @@
+#!/usr/local/bin/ruby -w
+
+require "rubygems"
+require "highline/import"
+
+tounge_twister = ask("... try saying that three times fast") do |q|
+  q.gather = 3
+  q.verify_match = true
+  q.responses[:mismatch] = "Nope, those don't match. Try again."
+end
+
+puts "Ok, you did it."
+
+pass = ask("Enter your password:  ") do |q|
+  q.echo = '*'
+  q.verify_match = true
+  q.gather = {"Enter a password" => '',
+              "Please type it again for verification" => ''}
+end
+
+puts "Your password is now #{pass}!"

--- a/lib/highline/menu.rb
+++ b/lib/highline/menu.rb
@@ -389,6 +389,8 @@ class HighLine
                      :not_in_range         =>
                        "Your answer isn't within the expected range " +
                        "(#{expected_range}).",
+                     :mismatch             =>
+                       "Your entries didn't match.",
                      :not_valid            =>
                        "Your answer isn't valid (must match " +
                        "#{@validate.inspect})."

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -49,19 +49,20 @@ class HighLine
       @in           = nil
       @confirm      = nil
       @gather       = false
+      @verify_match = false
       @first_answer = nil
       @directory    = Pathname.new(File.expand_path(File.dirname($0)))
       @glob         = "*"
       @responses    = Hash.new
       @overwrite    = false
-      
+
       # allow block to override settings
       yield self if block_given?
 
       # finalize responses based on settings
       build_responses
     end
-    
+
     # The ERb template of the question to be asked.
     attr_accessor :question
     # The type that will be used to convert this answer.
@@ -152,6 +153,12 @@ class HighLine
     # 
     attr_accessor :gather
     # 
+    # When set to +true+ multiple entries will be collected according to
+    # the setting for _gather_, except they will be required to match
+    # each other. Multiple identical entries will return a single answer.
+    #
+    attr_accessor :verify_match
+    #
     # When set to a non *nil* value, this will be tried as an answer to the
     # question.  If this answer passes validations, it will become the result
     # without the user ever being prompted.  Otherwise this value is discarded, 
@@ -236,6 +243,8 @@ class HighLine
                      :not_in_range         =>
                        "Your answer isn't within the expected range " +
                        "(#{expected_range}).",
+                     :mismatch             =>
+                       "Your entries didn't match.",
                      :not_valid            =>
                        "Your answer isn't valid (must match " +
                        "#{@validate.inspect})." }.merge(@responses)

--- a/test/tc_highline.rb
+++ b/test/tc_highline.rb
@@ -410,15 +410,72 @@ class TestHighLine < Test::Unit::TestCase
                   answers )
     assert_equal("Age:  Father's Age:  Wife's Age:  ", @output.string)
   end
- 
-  def test_lists 
+
+  def test_typing_verification
+    @input << "all work and no play makes jack a dull boy\n" * 3
+    @input.rewind
+
+    answer = @terminal.ask("How's work? ") do |q|
+      q.gather = 3
+      q.verify_match = true
+    end
+    assert_equal("all work and no play makes jack a dull boy", answer)
+
+    @input.truncate(@input.rewind)
+    @input << "all play and no work makes jack a mere toy\n"
+    @input << "all work and no play makes jack a dull boy\n" * 5
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    answer = @terminal.ask("How are things going? ") do |q|
+      q.gather = 3
+      q.verify_match = true
+      q.responses[:mismatch] = 'Typing mismatch!'
+      q.responses[:ask_on_error] = ''
+    end
+    assert_equal("all work and no play makes jack a dull boy", answer)
+
+    # now try using a hash for gather
+
+    @input.truncate(@input.rewind)
+    @input << "Password\nPassword\n"
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    answer = @terminal.ask("<%= @key %>: ") do |q|
+      q.verify_match = true
+      q.gather = {"Enter a password" => '', "Please type it again" => ''}
+    end
+    assert_equal("Password", answer)
+
+    @input.truncate(@input.rewind)
+    @input << "Password\nMistake\nPassword\nPassword\n"
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    answer = @terminal.ask("<%= @key %>: ") do |q|
+      q.verify_match = true
+      q.responses[:mismatch] = 'Typing mismatch!'
+      q.responses[:ask_on_error] = ''
+      q.gather = {"Enter a password" => '', "Please type it again" => ''}
+    end
+
+    assert_equal("Password", answer)
+    assert_equal( "Enter a password: " +
+                  "Please type it again: " +
+                  "Typing mismatch!\n" +
+                  "Enter a password: " +
+                  "Please type it again: ", @output.string )
+  end
+
+  def test_lists
     digits     = %w{Zero One Two Three Four Five Six Seven Eight Nine}
     erb_digits = digits.dup
     erb_digits[erb_digits.index("Five")] = "<%= color('Five', :blue) %%>"
-    
+
     @terminal.say("<%= list(#{digits.inspect}) %>")
     assert_equal(digits.map { |d| "#{d}\n" }.join, @output.string)
-    
+
     @output.truncate(@output.rewind)
 
     @terminal.say("<%= list(#{digits.inspect}, :inline) %>")


### PR DESCRIPTION
This adds the ability to request duplicate entries from the user to verify they typed their answer correctly.   One commonly seen example would be the double entry required when setting or changing a password.   A simple example script is included for reference.
