### PR TITLE
HighLine#say doesn't handle colorized strings correctly

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -611,8 +611,7 @@ class HighLine
 
     # Don't add a newline if statement ends with whitespace, OR
     # if statement ends with whitespace before a color escape code.
-    if statement[-1, 1] == " " or statement[-1, 1] == "\t" or
-        (/\s\e\[\d+(;\d+)*m\Z/ =~ statement)
+    if /[ \t](\e\[\d+(;\d+)*m)?\Z/ =~ statement
       @output.print(statement)
       @output.flush  
     else

--- a/test/tc_highline.rb
+++ b/test/tc_highline.rb
@@ -839,6 +839,28 @@ class TestHighLine < Test::Unit::TestCase
 
     @terminal.say("This will not have a newline.  ")
     assert_equal("This will not have a newline.  ", @output.string)
+
+    @output.truncate(@output.rewind)
+    
+    @terminal.say("This will not\n end with a newline. ")
+    assert_equal("This will not\n end with a newline. ", @output.string)
+
+    @output.truncate(@output.rewind)
+
+    @terminal.say("This will \nend with a newline.")
+    assert_equal("This will \nend with a newline.\n", @output.string)
+
+    @output.truncate(@output.rewind)
+
+    colorized = @terminal.color("This will not have a newline. ", :green)
+    @terminal.say(colorized)
+    assert_equal("\e[32mThis will not have a newline. \e[0m", @output.string)
+
+    @output.truncate(@output.rewind)
+
+    colorized = @terminal.color("This will have a newline.", :green)
+    @terminal.say(colorized)
+    assert_equal("\e[32mThis will have a newline.\e[0m\n", @output.string)
   end
 
   def test_type_conversion


### PR DESCRIPTION
The original `HighLine#say` method will correctly not emit a newline with the statement (displaying with `print` and `flush`) when it ends in whitespace. However, if one creates a string ending in whitespace and then uses `HighLine#color` to colorize it, `HighLine#say` will emit the newline, which is rarely-if-ever the intended behavior. I have modified the method to cause it to `print` and `flush` (no newline) when the statement string ends with whitespace directly preceding a color code, by way of a regex.
