### PR TITLE
Removing assignment for unused variable.

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -813,8 +813,6 @@ class HighLine
   def get_response(  )
     return @question.first_answer if @question.first_answer?
 
-    stty = (CHARACTER_MODE == "stty")
-
     if @question.character.nil?
       if @question.echo == true and @question.limit.nil?
         get_line


### PR DESCRIPTION
Since commit 2abb2c74649f96564249e5bd21a2b3a39d00656f the variable `stty` is not used anymore and causes a warning for unused but assigned variable.
