### PR TITLE
Feature: indentation for text

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -174,13 +174,13 @@ class HighLine
   # and _output_.
   #
   def initialize( input = $stdin, output = $stdout,
-                  wrap_at = nil, page_at = nil )
+                  wrap_at = nil, page_at = nil, indent_size=3, indent_level=0 )
     super()
     @input   = input
     @output  = output
 
-    # Default indentation size
-    @indent = 3
+    @indent_size = indent_size
+    @indent_level = indent_level
 
     self.wrap_at = wrap_at
     self.page_at = page_at
@@ -202,7 +202,9 @@ class HighLine
   # The current row setting for paging output.
   attr_reader :page_at
   # The indentation size
-  attr_writer :indent
+  attr_writer :indent_size
+  # The indentation level
+  attr_writer :indent_level
 
   #
   # A shortcut to HighLine.ask() a question that only accepts "yes" or "no"
@@ -262,7 +264,7 @@ class HighLine
         if @question.confirm
           # need to add a layer of scope to ask a question inside a
           # question, without destroying instance data
-          context_change = self.class.new(@input, @output, @wrap_at, @page_at)
+          context_change = self.class.new(@input, @output, @wrap_at, @page_at, @indent_size, @indent_level)
           if @question.confirm == true
             confirm_question = "Are you sure?  "
           else
@@ -617,10 +619,10 @@ class HighLine
     # Don't add a newline if statement ends with whitespace, OR
     # if statement ends with whitespace before a color escape code.
     if /[ \t](\e\[\d+(;\d+)*m)?\Z/ =~ statement
-      @output.print(statement)
+      @output.print(indentation+statement)
       @output.flush
     else
-      @output.puts(statement)
+      @output.puts(indentation+statement)
     end
   end
 
@@ -645,10 +647,23 @@ class HighLine
   end
 
   #
-  # Outputs indentation with specified level
+  # Outputs indentation with current settings
   #
-  def indent(level=1)
-    return ' '*@indent*level
+  def indentation
+    return ' '*@indent_size*@indent_level
+  end
+
+  #
+  # Executes block or outputs statement with indentation
+  #
+  def indent(increase=1, statement=nil)
+    @indent_level+=increase
+    if block_given?
+        yield self
+    else
+        say(statement)
+    end
+    @indent_level-=increase
   end
 
   #

--- a/test/tc_highline.rb
+++ b/test/tc_highline.rb
@@ -72,13 +72,46 @@ class TestHighLine < Test::Unit::TestCase
 
   def test_indent
     text = "Testing...\n"
-    @terminal.say(@terminal.indent+text)
+    @terminal.indent_level=1
+    @terminal.say(text)
     assert_equal(' '*3+text, @output.string)
 
     @output.truncate(@output.rewind)
-    @terminal.indent=5
-    @terminal.say(@terminal.indent(2)+text)
+    @terminal.indent_level=3
+    @terminal.say(text)
+    assert_equal(' '*9+text, @output.string)
+
+    @output.truncate(@output.rewind)
+    @terminal.indent_level=0
+    @terminal.indent_size=5
+    @terminal.indent(2, text)
     assert_equal(' '*10+text, @output.string)
+
+    @output.truncate(@output.rewind)
+    @terminal.indent_size=4
+    @terminal.indent {
+        @terminal.say(text)
+    }
+    assert_equal(' '*4+text, @output.string)
+
+    @output.truncate(@output.rewind)
+    @terminal.indent_size=2
+    @terminal.indent(3) { |t|
+        t.say(text)
+    }
+    assert_equal(' '*6+text, @output.string)
+
+    @output.truncate(@output.rewind)
+    @terminal.indent { |t|
+        t.indent {
+            t.indent {
+                t.indent { |tt|
+                    tt.say(text)
+                }
+            }
+        }
+    }
+    assert_equal(' '*8+text, @output.string)
   end
   
   def test_newline


### PR DESCRIPTION
Sometimes there's need to indent text and it's quite related functionality so I added such feature.

can use it like

``` ruby
indent=2
say(indent(2)+"Some text")
say(indent+"More text")
```

Also I added `newline` method because I think it's more handy than `"\n"`

I created few tests for this feature and all changes are fully backward compatible.
