### PR TITLE
Allow so that indentation size and level can be also read not only written

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -202,9 +202,9 @@ class HighLine
   # The current row setting for paging output.
   attr_reader :page_at
   # The indentation size
-  attr_writer :indent_size
+  attr_accessor :indent_size
   # The indentation level
-  attr_writer :indent_level
+  attr_accessor :indent_level
 
   #
   # A shortcut to HighLine.ask() a question that only accepts "yes" or "no"


### PR DESCRIPTION
I didn't thought about it much but now I realized that it should be also readable not only writable, so app can read current indentation level without keeping track of what it was changed to. As now currently there's no way for app to determine what's current indention level.
