### PR TITLE
Separate auto-completion from answer type 

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -324,6 +324,8 @@ class HighLine
     @menu = @question = Menu.new(&details)
     @menu.choices(*items) unless items.empty?
 
+    # Set auto-completion
+    @menu.completion = @menu.options
     # Set _answer_type_ so we can double as the Question for ask().
     @menu.answer_type = if @menu.shell
       lambda do |command|    # shell-style selection

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -33,6 +33,7 @@ class HighLine
       # initialize instance data
       @question    = question.dup
       @answer_type = answer_type
+      @completion = @answer_type
 
       @character    = nil
       @limit        = nil
@@ -65,6 +66,8 @@ class HighLine
     attr_accessor :question
     # The type that will be used to convert this answer.
     attr_accessor :answer_type
+    # For Auto-completion
+    attr_accessor :completion
     #
     # Can be set to +true+ to use HighLine's cross-platform character reader
     # instead of fetching an entire line of input.  (Note: HighLine's character
@@ -421,9 +424,9 @@ class HighLine
     # Pathname.  Any other time, this method will return an empty Array.
     #
     def selection(  )
-      if @answer_type.is_a?(Array)
-        @answer_type
-      elsif [File, Pathname].include?(@answer_type)
+      if @completion.is_a?(Array)
+        @completion
+      elsif [File, Pathname].include?(@completion)
         Dir[File.join(@directory.to_s, @glob)].map do |file|
           File.basename(file)
         end


### PR DESCRIPTION
I think it's quite bad design to mix answer conversion and auto-completion using same variable `answer_type`. So this is a little separation giving more control to app, ie. allowing to enable auto-competition without requiring that answer will be enforced to exact value from array.

eg. (user is still allowed to input 'yellow', but can use completion for green)

``` ruby
ask("color?") { |h|
            h.validate = nil
            h.readline = true
            h.completion=["red","green","blue"]
        }
```

if `completion` isn't specified it will be same as `answer_type` thus consistent with that it used to be.

this also kinda fixes #65, but probably it can be improved with more functionality.
