### PR TITLE
Use the configured streams on JRuby with JLine

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -175,7 +175,6 @@ class HighLine
   #
   def initialize( input = $stdin, output = $stdout,
                   wrap_at = nil, page_at = nil, indent_size=3, indent_level=0 )
-    super()
     @input   = input
     @output  = output
 
@@ -193,6 +192,8 @@ class HighLine
     @gather   = nil
     @answers  = nil
     @key      = nil
+
+    initialize_system_extensions if respond_to?(:initialize_system_extensions)
   end
 
   include HighLine::SystemExtensions

--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -11,13 +11,13 @@ class HighLine
   module SystemExtensions
     JRUBY = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
-    def initialize
-      if JRUBY
+    if JRUBY
+      def initialize_system_extensions
         require 'java'
         if JRUBY_VERSION =~ /^1.7/
           java_import 'jline.console.ConsoleReader'
 
-          @java_console = ConsoleReader.new($stdin.to_inputstream, $stdout.to_outputstream)
+          @java_console = ConsoleReader.new(@input.to_inputstream, @output.to_outputstream)
           @java_console.set_history_enabled(false)
           @java_console.set_bell_enabled(true)
           @java_console.set_pagination_enabled(false)
@@ -28,8 +28,8 @@ class HighLine
           java_import 'jline.ConsoleReader'
           java_import 'jline.Terminal'
 
-          @java_input = Channels.newInputStream($stdin.to_channel)
-          @java_output = OutputStreamWriter.new(Channels.newOutputStream($stdout.to_channel))
+          @java_input = Channels.newInputStream(@input.to_channel)
+          @java_output = OutputStreamWriter.new(Channels.newOutputStream(@output.to_channel))
           @java_terminal = Terminal.getTerminal
           @java_console = ConsoleReader.new(@java_input, @java_output)
           @java_console.setUseHistory(false)


### PR DESCRIPTION
Without this change, the input and output parameters to `HighLine.new` are ignored for `#ask` (both for specifying the input stream and for displaying the prompt).

This addresses issue #31, though not completely — while it allows the tests to run on JRuby, many of them fail.

With this patch applied, the tests run to completion on JRuby 1.7.3:

```
94 tests, 743 assertions, 22 failures, 1 errors, 0 skips
```

On JRuby 1.6.8, they get further than they do without the patch, but many of them error out (as opposed to failing). The test run slows and eventually hangs before completing. The problem on 1.6.8 seems to be that the runner is running out of heap space.

For both JRuby 1.7.3 and 1.6.8, though, HighLine does better with this patch than without it so I'm submitting it for review.
