### PR TITLE
Make methods in SystemExtensions public

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -39,8 +39,6 @@ class HighLine
       end
     end
 
-    module_function
-
     #
     # This section builds character reading and terminal size functions
     # to suit the proper platform we're running on.  Be warned:  Here be


### PR DESCRIPTION
This is an attempt to fix https://github.com/JEG2/highline/issues/57

Most of the methods rely on instance variables, so it does not make sense that they should be available as module methods. But when they are included into the HighLine class, they are private, so not useful outside of the class.

Making the methods public doesn't seem to have a negative effect on test results, and it allows the methods to be called on instances of the HighLine class.

This might break some stuff.
