### PR TITLE
`flush` output after `say`

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -628,10 +628,10 @@ class HighLine
     # if statement ends with whitespace before a color escape code.
     if /[ \t](\e\[\d+(;\d+)*m)?\Z/ =~ statement
       @output.print(indentation+statement)
-      @output.flush
     else
       @output.puts(indentation+statement)
     end
+    @output.flush
   end
 
   #


### PR DESCRIPTION
Any reason why in `say` there's `flush` after `print` but not after `puts`?

I've noticed that if I pipe output to file, it's not written there until exit of program, but once I do `say('text ')` it's flushed/written to file and I think it's quite inconsistent/confusing

this PR adds flush after both print/puts :)
