### PR TITLE
Adding support for non US-ASCII encoded menu items

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -616,6 +616,10 @@ class HighLine
     statement = statement.to_str
     return unless statement.length > 0
 
+    # Allow non-ascii menu prompts in ruby > 1.9.2. ERB eval the menu statement
+    # with the environment's default encoding(usually utf8)
+    statement.force_encoding(Encoding.default_external) if defined?(Encoding) && Encoding.default_external
+
     template  = ERB.new(statement, nil, "%")
     statement = template.result(binding)
 

--- a/test/tc_menu.rb
+++ b/test/tc_menu.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # tc_menu.rb
 #
 #  Created by Gregory Thomas Brown on 2005-05-10.
@@ -64,6 +65,17 @@ class TestMenu < Test::Unit::TestCase
       menu.choice "Sample3"  
     end
     assert_equal("Sample1, Sample2 or Sample3?  ", @output.string)
+  end
+  
+  def test_unicode_flow
+    @input << "1\n"
+    @input.rewind
+
+    @terminal.choose do |menu|
+      # Default:  menu.flow = :rows
+      menu.choice "Unicode right single quotation mark: ’"
+    end
+    assert_equal("1. Unicode right single quotation mark: ’\n?  ", @output.string)
   end
 
   def test_help


### PR DESCRIPTION
- Eval the menu template in the interpreter's default_external encoding,
  which will probably be utf8, or something like windows-1252 on win32
- Added test with utf8 char in it
