### PR TITLE
Don't force encoding if string is frozen

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -618,7 +618,7 @@ class HighLine
 
     # Allow non-ascii menu prompts in ruby > 1.9.2. ERB eval the menu statement
     # with the environment's default encoding(usually utf8)
-    statement.force_encoding(Encoding.default_external) if defined?(Encoding) && Encoding.default_external
+    statement.force_encoding(Encoding.default_external) if not statement.frozen? and defined?(Encoding) and Encoding.default_external
 
     template  = ERB.new(statement, nil, "%")
     statement = template.result(binding)


### PR DESCRIPTION
Currently HighLine forces encoding in `#say`, but that would change string in-place and incase it's frozen it would fail.

This following code doesn't work without this patch

``` ruby
HighLine.new.say('Oh no'.freeze)
```

results in

```
RuntimeError: can't modify frozen String
        from /var/lib/ruby/gems/2.0.0/gems/highline-1.6.19/lib/HighLine.rb:621:in `force_encoding'
        from /var/lib/ruby/gems/2.0.0/gems/highline-1.6.19/lib/HighLine.rb:621:in `say'
```

PS. actually I think Ruby does wrong in this case it should be `force_encoding!` because it does change original string and there should be another method without `!` which would return new string.
