### PR TITLE
fix indentation if exception is raised inside `indent`

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -661,10 +661,16 @@ class HighLine
     @indent_level += increase
     multi = @multi_indent
     @multi_indent = multiline unless multiline.nil?
-    if block_given?
-        yield self
-    else
-        say(statement)
+    begin
+        if block_given?
+            yield self
+        else
+            say(statement)
+        end
+    rescue
+        @multi_indent = multi
+        @indent_level -= increase
+        raise
     end
     @multi_indent = multi
     @indent_level -= increase


### PR DESCRIPTION
for example suppose such code

``` ruby
h = HighLine.new
h.say('some line')
begin
    h.indent {
        h.say(1 / 0)
    }
rescue
end
h.say('another line')
```

this PR fixes it so that `another line` won't be indented. Currently it would be indented because exception would happen before `indent` could revert state.
