### PR TITLE
modify repeat_entry.rb example

### DIFF
--- a/examples/repeat_entry.rb
+++ b/examples/repeat_entry.rb
@@ -11,7 +11,7 @@ end
 
 puts "Ok, you did it."
 
-pass = ask("Enter your password:  ") do |q|
+pass = ask("<%= @key %>:  ") do |q|
   q.echo = '*'
   q.verify_match = true
   q.gather = {"Enter a password" => '',


### PR DESCRIPTION
fixes #87 

Just an example change to better illustrate usage of gather with a hash as it wasn't obvious to me to use erb to access the @key in the question (unfamiliarity with highline).

Prior to this change, the example would ask "Enter your password:  " twice.
Now uses hash entries as the question and asks "Enter a password:  " followed by "Please type it again for verification:   "
