### PR TITLE
Require 'readline' on JRuby

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -14,6 +14,7 @@ class HighLine
     if JRUBY
       def initialize_system_extensions
         require 'java'
+        require 'readline'
         if JRUBY_VERSION =~ /^1.7/
           java_import 'jline.console.ConsoleReader'
 


### PR DESCRIPTION
Starting with JRuby 1.7.5, explicit require is required to make use of
jline. (https://github.com/jruby/jruby/issues/1017#issuecomment-24543488)
