### PR TITLE
Fix "undefined local variable or method `stdscr'" error. This is happeni...

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -180,7 +180,7 @@ class HighLine
               size = [80, 40]
               FFI::NCurses.initscr
               begin
-                size = FFI::NCurses.getmaxyx(stdscr).reverse
+                size = FFI::NCurses.getmaxyx(FFI::NCurses.stdscr).reverse
               ensure
                 FFI::NCurses.endwin
               end


### PR DESCRIPTION
I'm using the knife-essentials gem for chef on OSX, which uses highline. This error doesn't seem to be something that's dependent on that context, though.

Here's the stack trace I got:

```
{gems_root}/highline-1.6.19/lib/highline/system_extensions.rb:179:in `terminal_size': undefined local variable or method `stdscr' for HighLine::SystemExtensions:Module (NameError)
    from {gems_root}/knife-essentials-1.5.4/lib/chef/knife/list_essentials.rb:128:in `print_results'
    from {gems_root}/knife-essentials-1.5.4/lib/chef/knife/list_essentials.rb:118:in `print_result_paths'
    from {gems_root}/knife-essentials-1.5.4/lib/chef/knife/list_essentials.rb:86:in `run'
    from {gems_root}/chef-11.6.0/lib/chef/knife.rb:466:in `run_with_pretty_exceptions'
    from {gems_root}/chef-11.6.0/lib/chef/knife.rb:173:in `run'
    from {gems_root}/chef-11.6.0/lib/chef/application/knife.rb:123:in `run'
    from {gems_root}/chef-11.6.0/bin/knife:25:in `<top (required)>'
```

Adding in the namespace of FFI::NCurses seems to fix the problem.
