### PR TITLE
fixes undefined method GetConsoleScreenBufferInfo and undefined method GetStdHandle on Windows running Ruby 1.8.7

### DIFF
--- a/lib/highline/system_extensions.rb
+++ b/lib/highline/system_extensions.rb
@@ -95,6 +95,16 @@ class HighLine
           extern "unsigned long _getch()"
           extern "unsigned long GetConsoleScreenBufferInfo(unsigned long, void*)"
           extern "unsigned long GetStdHandle(unsigned long)"
+
+          # Ruby 1.8 DL::Importable.import does mname[0,1].downcase so FooBar becomes fooBar
+          if defined?(getConsoleScreenBufferInfo)
+            alias_method :GetConsoleScreenBufferInfo, :getConsoleScreenBufferInfo
+            module_function :GetConsoleScreenBufferInfo
+          end
+          if defined?(getStdHandle)
+            alias_method :GetStdHandle, :getStdHandle
+            module_function :GetStdHandle
+          end
         end
       end
 


### PR DESCRIPTION
Added alias_method to fix "undefined method GetConsoleScreenBufferInfo" and "undefined method GetStdHandle" on Windows running Ruby 1.8.7
