### PR TITLE
Correctly encode statements to output encoding

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -617,13 +617,15 @@ class HighLine
     statement = format_statement(statement)
     return unless statement.length > 0
 
-      # Don't add a newline if statement ends with whitespace, OR
+    out = (indentation+statement).encode(@output.external_encoding, { :undef => :replace  } )
+
+    # Don't add a newline if statement ends with whitespace, OR
     # if statement ends with whitespace before a color escape code.
     if /[ \t](\e\[\d+(;\d+)*m)?\Z/ =~ statement
-      @output.print(indentation+statement)
+      @output.print(out)
       @output.flush
     else
-      @output.puts(indentation+statement)
+      @output.puts(out)
     end
   end
 
@@ -710,10 +712,6 @@ class HighLine
   def format_statement statement
     statement = (statement || "").dup.to_str
     return statement unless statement.length > 0
-
-  # Allow non-ascii menu prompts in ruby > 1.9.2. ERB eval the menu statement
-    # with the environment's default encoding(usually utf8)
-    statement.force_encoding(Encoding.default_external) if defined?(Encoding) && Encoding.default_external
 
     template  = ERB.new(statement, nil, "%")
     statement = template.result(binding)

--- a/test/tc_menu.rb
+++ b/test/tc_menu.rb
@@ -75,7 +75,7 @@ class TestMenu < Test::Unit::TestCase
       # Default:  menu.flow = :rows
       menu.choice "Unicode right single quotation mark: ’"
     end
-    assert_equal("1. Unicode right single quotation mark: ’\n?  ", @output.string)
+    assert_equal("1. Unicode right single quotation mark: ’\n?  ".encode(@output.external_encoding, { :undef => :replace }), @output.string)
   end
 
   def test_help


### PR DESCRIPTION
This resolves #108

It's a shame that people so often get it wrong. Basically idea is that as soon as you receive input from "outside" encode it in your preferred internal encoding (eg. UTF8) then process everything and finally encode it back to encoding which is wanted by "outside".

In this case in Ruby code we use and process UTF8, but when we need to output text we encode it in respective encoding. Obviously if we use some Unicode characters in our code and if "outside" uses just ASCII they'll be "?" but that's not our problem.

I wonder why `@output.print` doesn't do this automagically, because it knows that output encoding is different than one we pass to print so IMO it should either encode it or raise exception. It looks like Ruby's bug. Then 620 line wouldn't be needed.

By the way, I haven't checked other places. This fixes only `say` proper output.
