### PR TITLE
Fix issue #113

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -259,7 +259,7 @@ class HighLine
     # the prompt will not be issued. And we have to account for that now.
     # Also, JRuby-1.7's ConsoleReader.readLine() needs to be passed the prompt
     # to handle line editing properly.
-    say(@question) unless ((JRUBY or @question.readline) and @question.echo == true)
+    say(@question) unless ((JRUBY or @question.readline) and (@question.echo == true and @question.limit.nil?))
 
     begin
       @answer = @question.answer_or_default(get_response)


### PR DESCRIPTION
Fix #113 
(commit message of b4160cd) 
At HighLine#get_response there's a test for @question.limit.nil? So it enters "readline mode" only if test pass. Else, it falls back to char-by-char mode. As "readline mode" takes care of "saying" the question by itself, HighLine#ask bypasses the "saying phase" delegating it to HighLine#get_line.
So, we shouldn't bypass the "saying phase" at HighLine#ask unless @question.limit.nil?