### PR TITLE
Issue #112

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -249,7 +249,7 @@ class HighLine
   #
   # Raises EOFError if input is exhausted.
   #
-  def ask( question, answer_type = String, &details ) # :yields: question
+  def ask( question, answer_type = nil, &details ) # :yields: question
     @question ||= Question.new(question, answer_type, &details)
 
     return gather if @question.gather

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -228,8 +228,7 @@ class HighLine
     # Also used by Menu#update_responses.
     #
     def build_responses(message_source = answer_type, new_hash_wins = false)
-
-      append_default unless default.nil?
+      append_default if [::String, Symbol].include? default.class
 
       choice_error_str_func = lambda do
         message_source.is_a?(Array) \

--- a/test/tc_highline.rb
+++ b/test/tc_highline.rb
@@ -486,6 +486,51 @@ class TestHighLine < Test::Unit::TestCase
                   @output.string )
   end
 
+  def test_default_with_String
+    @input << "\n"
+    @input.rewind
+
+    answer = @terminal.ask("Question:  ") do |q|
+      q.default = "string"
+    end
+
+    assert_equal "string", answer
+    assert_equal "Question:  |string|  ", @output.string
+  end
+
+  def test_default_with_Symbol
+    # With a Symbol, it should show up the String version
+    #   at prompt, but return the Symbol as answer
+
+    @input << "\n"
+    @input.rewind
+
+    answer = @terminal.ask("Question:  ") do |q|
+      q.default = :string
+    end
+
+    assert_equal :string, answer
+    assert_equal "Question:  |string|  ", @output.string
+  end
+
+  def test_default_with_non_String_objects
+    # With a non-string object, it should not show
+    #   any 'default' at prompt line. And should
+    #   return the "default" object, without conversion.
+
+    @input << "\n"
+    @input.rewind
+
+    default_non_string_object = Object.new
+
+    answer = @terminal.ask("Question:  ") do |q|
+      q.default = default_non_string_object
+    end
+
+    assert_equal default_non_string_object, answer
+    assert_equal "Question:  ", @output.string
+  end
+
   def test_string_preservation
     @input << "Maybe\nYes\n"
     @input.rewind


### PR DESCRIPTION
I think this accomplish what @danielpclark was asking at #112 
- No answer conversions to String occurs by default (only explicitly)
- No "default value" is appended to prompt if default object class is not String or Symbol