### PR TITLE
Adds customizable default styles +  placeholder

### DIFF
--- a/examples/default_style.rb
+++ b/examples/default_style.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+# default_style.rb
+#
+#  Created by Donald Guy on 2015-02-12
+
+require 'rubygems'
+require 'highline/import'
+
+ask("Brackets right?") do |q|
+    q.default = "yes"
+    q.default_style = %w/[ ]/
+end
+
+ask("old school? ") do |q|
+    q.default = "yes"
+    q.default_style = "|"
+end
+
+ask("erb? ") do |q|
+    q.default = "possible"
+    q.default_style = ["[<%= color('", "', RED, BOLD) %>]"]
+end
+
+ask("placeholder? ") do |q|
+    q.default = "so fancy"
+    q.default_style = :placeholder
+end
+

--- a/examples/placeholder.rb
+++ b/examples/placeholder.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# placeholder.rb
+#
+#  Created by Donald Guy on 2015-02-12
+
+require 'rubygems'
+require 'highline/import'
+
+name = ask("What's your name?") do |q|
+    q.default = "#{ENV['USER']}"
+    q.default_style = :placeholder
+    q.placeholder_color = :red
+end
+say("Your name is <%= color('#{name}', GREEN) %>")


### PR DESCRIPTION
I just wanted the placeholder functionality, but while I was in there
 figured I'd add the other customizations that seemed reasonable

To quote from the comment I added:
Choose a style in which to display the default. Options include:
  - nil (unset), traditional behavior, equivalent to "|"
  - a string, in which case it will wrap the value
  - a two element array of strings, "before" and "after" e.g. `[ "[", "]" ]`
    a notable special case is `[ "<%= color('", "', BOLD) %>" ]`
  - `:placeholder`, in which case it will act like a [HTML5](https://html.spec.whatwg.org/multipage/forms.html#the-placeholder-attribute) placeholder 
     attribute, disappearing and reappearing if an alternative is typed or deleted
