### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,9 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.0
+  - rbx-2
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - rvm: rbx-2


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I am trying to add this to ensure this Gem works in Rubinius and to complete this dashboard: http://bjfish.github.io/rubinius-gem-build-status/page2/.