### PR TITLE
Added current gem version to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,7 @@
 by James Edward Gray II
 
 {<img src="https://travis-ci.org/JEG2/highline.svg" alt="Build Status" />}[https://travis-ci.org/JEG2/highline]
+{<img src="https://img.shields.io/gem/v/highline.svg?style=flat" />}[http://rubygems.org/gems/highline]
 
 == Description
 


### PR DESCRIPTION
This is very useful when verifying if I run the latest version. It fetches the version automatically from RubyGems.org

The badge has the same design as the travis one.