### PR TITLE
Add HighLine::Simulator test - Closes #142

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.0
+  - 2.2.1
+  - 2.2.2
   - rbx-2
 notifications:
   email: false

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+### 1.7.3 / 2015-06-29
+* Add HighLine::Simulator tests (Bala Paranj (@bparanj) and Abinoam Marques Jr. (@abinoam), #142, PR #143)
+
 ### 1.7.2 / 2015-04-19
 
 #### Bug fixes

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -1,4 +1,4 @@
 class HighLine
   # The version of the installed library.
-  VERSION = "1.7.2".freeze
+  VERSION = "1.7.3".freeze
 end

--- a/test/tc_simulator.rb
+++ b/test/tc_simulator.rb
@@ -1,0 +1,23 @@
+require 'test/unit'
+require 'highline/import'
+require 'highline/simulate'
+
+class SimulatorTest < Test::Unit::TestCase
+  def setup
+    input     = StringIO.new
+    output    = StringIO.new
+    $terminal = HighLine.new(input, output)
+  end
+
+  def test_simulator
+    HighLine::Simulate.with('Bugs Bunny', '18') do
+      name = ask('What is your name?')
+
+      assert_equal 'Bugs Bunny', name
+
+      age = ask('What is your age?')
+
+      assert_equal '18', age
+    end
+  end
+end


### PR DESCRIPTION
* Added tests for HighLine::Simulator as suggested by @bparanj on #142
* Update travis matrix to include the 2.2.1 and 2.2.2 versions of Ruby
