### PR TITLE
Fix SimpleCov configuration and add some tests

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+unless SimpleCov.running
+  SimpleCov.start do
+    add_filter "test_"
+  end
+end

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -314,7 +314,7 @@ class HighLine
     # completed for any reason.
     #
     def convert
-      Question::AnswerConverter.new(self).convert
+      AnswerConverter.new(self).convert
     end
 
     def check_range

--- a/lib/highline/question/answer_converter.rb
+++ b/lib/highline/question/answer_converter.rb
@@ -23,18 +23,6 @@ class HighLine
         answer
       end
 
-      private
-
-      def convert_by_answer_type
-        if answer_type.respond_to? :parse
-          answer_type.parse(answer)
-        elsif answer_type.is_a? Class
-          send("to_#{answer_type.name.downcase}")
-        else
-          send("to_#{answer_type.class.name.downcase}")
-        end
-      end
-
       def to_string
         HighLine::String(answer)
       end
@@ -78,6 +66,18 @@ class HighLine
 
       def to_proc
         answer_type.call(answer)
+      end
+
+      private
+
+      def convert_by_answer_type
+        if answer_type.respond_to? :parse
+          answer_type.parse(answer)
+        elsif answer_type.is_a? Class
+          send("to_#{answer_type.name.downcase}")
+        else
+          send("to_#{answer_type.class.name.downcase}")
+        end
       end
     end
   end

--- a/lib/highline/question/answer_converter.rb
+++ b/lib/highline/question/answer_converter.rb
@@ -29,54 +29,54 @@ class HighLine
         if answer_type.respond_to? :parse
           answer_type.parse(answer)
         elsif answer_type.is_a? Class
-          send(answer_type.name)
+          send("to_#{answer_type.name.downcase}")
         else
-          send(answer_type.class.name)
+          send("to_#{answer_type.class.name.downcase}")
         end
       end
 
-      def String
+      def to_string
         HighLine::String(answer)
       end
 
       # That's a weird name for a method!
       # But it's working ;-)
-      define_method "HighLine::String" do
+      define_method "to_highline::string" do
         HighLine::String(answer)
       end
 
-      def Integer
+      def to_integer
         Kernel.send(:Integer, answer)
       end
 
-      def Float
+      def to_float
         Kernel.send(:Float, answer)
       end
 
-      def Symbol
+      def to_symbol
         answer.to_sym
       end
 
-      def Regexp
+      def to_regexp
         Regexp.new(answer)
       end
 
-      def File
+      def to_file
         self.answer = choices_complete(answer)
         File.open(File.join(directory.to_s, answer.last))
       end
 
-      def Pathname
+      def to_pathname
         self.answer = choices_complete(answer)
         Pathname.new(File.join(directory.to_s, answer.last))
       end
 
-      def Array
+      def to_array
         self.answer = choices_complete(answer)
         answer.last
       end
 
-      def Proc
+      def to_proc
         answer_type.call(answer)
       end
     end

--- a/test/test_answer_converter.rb
+++ b/test/test_answer_converter.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# coding: utf-8
+
+require "test_helper"
+
+require "highline/question"
+
+class TestAnswerConverter < Minitest::Test
+  def test_integer_convertion
+    question = HighLine::Question.new("What's your age?", Integer)
+    question.answer = "18"
+    answer_converter = HighLine::Question::AnswerConverter.new(question)
+
+    refute_equal "18", answer_converter.convert
+    assert_equal   18, answer_converter.convert
+  end
+
+  def test_float_convertion
+    question = HighLine::Question.new("Write PI", Float)
+    question.answer = "3.14159"
+    answer_converter = HighLine::Question::AnswerConverter.new(question)
+
+    refute_equal "3.14159", answer_converter.convert
+    assert_equal   3.14159, answer_converter.convert
+  end
+end

--- a/test/test_color_scheme.rb
+++ b/test/test_color_scheme.rb
@@ -8,7 +8,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,4 @@ end
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
+require "minitest/autorun"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,9 @@
 
 require 'simplecov'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+if ENV['CODECLIMATE_REPO_TOKEN']
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+end
 
 require "minitest/autorun"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,6 @@
 # coding: utf-8
 
 require 'simplecov'
-SimpleCov.start do
-  add_filter "test_"
-end
 
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -407,6 +407,14 @@ class TestHighLine < Minitest::Test
     @terminal.say("This should be <%= ON_RGB_C06030 %>on_rgb_c06030<%= CLEAR %>!")
     assert_equal("This should be \e[48;5;173mon_rgb_c06030\e[0m!\n", @output.string)
 
+    # Relying on const_missing
+    assert_instance_of HighLine::Style, HighLine::ON_RGB_C06031_STYLE
+    assert_instance_of String         , HighLine::ON_RGB_C06032
+    assert_raises(NameError)          { HighLine::ON_RGB_ZZZZZZ }
+
+    # Retrieving color_code from a style
+    assert_equal "\e[41m", @terminal.color_code([HighLine::ON_RED_STYLE])
+
     @output.truncate(@output.rewind)
     
     # Does class method work, too?

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1046,6 +1046,24 @@ class TestHighLine < Minitest::Test
                   "?  ", @output.string )
 
     @input.truncate(@input.rewind)
+    @input << "-541\n11\n6\n"
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    answer = @terminal.ask("Enter a low even number:  ", Integer) do |q|
+      q.above = 0
+      q.below = 10
+    end
+    assert_equal(6, answer)
+    assert_equal( "Enter a low even number:  " +
+                  "Your answer isn't within the expected range " +
+                  "(above 0 and below 10).\n" +
+                  "?  " +
+                  "Your answer isn't within the expected range " +
+                  "(above 0 and below 10).\n" +
+                  "?  ", @output.string )
+
+    @input.truncate(@input.rewind)
     @input << "1\n-541\n6\n"
     @input.rewind
     @output.truncate(@output.rewind)

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -8,7 +8,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -498,6 +498,35 @@ class TestHighLine < Minitest::Test
                   @output.string )
   end
   
+  def test_generic_confirm_with_true
+    @input << "junk.txt\nno\nsave.txt\ny\n"
+    @input.rewind
+
+    answer = @terminal.ask("Enter a filename:  ") do |q|
+      q.confirm = true
+      q.responses[:ask_on_error] = :question
+    end
+    assert_equal("save.txt", answer)
+    assert_equal( "Enter a filename:  " +
+                  "Are you sure?  " +
+                  "Enter a filename:  " +
+                  "Are you sure?  ",
+                  @output.string )
+
+    @input.truncate(@input.rewind)
+    @input << "junk.txt\nyes\nsave.txt\nn\n"
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    answer = @terminal.ask("Enter a filename:  ") do |q|
+      q.confirm = true
+    end
+    assert_equal("junk.txt", answer)
+    assert_equal( "Enter a filename:  " +
+                  "Are you sure?  ",
+                  @output.string )
+  end
+
   def test_defaults
     @input << "\nNo Comment\n"
     @input.rewind

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1313,6 +1313,20 @@ class TestHighLine < Minitest::Test
 
     @input.rewind
 
+    answer = @terminal.ask("Enter a whitespace filled string:  ") do |q|
+      q.whitespace = :strip
+    end
+    assert_equal("A   lot\tof  \t  space\t  \there!", answer)
+
+    @input.rewind
+
+    answer = @terminal.ask("Enter a whitespace filled string:  ") do |q|
+      q.whitespace = :collapse
+    end
+    assert_equal(" A lot of space here! ", answer)
+
+    @input.rewind
+
     answer = @terminal.ask("Enter a whitespace filled string:  ")
     assert_equal("A   lot\tof  \t  space\t  \there!", answer)
 
@@ -1334,6 +1348,13 @@ class TestHighLine < Minitest::Test
 
     answer = @terminal.ask("Enter a whitespace filled string:  ") do |q|
       q.whitespace = :none
+    end
+    assert_equal("  A   lot\tof  \t  space\t  \there!   \n", answer)
+
+    @input.rewind
+
+    answer = @terminal.ask("Enter a whitespace filled string:  ") do |q|
+      q.whitespace = nil
     end
     assert_equal("  A   lot\tof  \t  space\t  \there!   \n", answer)
   end

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -97,7 +97,6 @@ class TestHighLine < Minitest::Test
     assert_raises(EOFError) { @terminal.ask("Any input left?  ", HighLine::String) }
   end
 
-
   def test_indent
     text = "Testing...\n"
     @terminal.indent_level=1
@@ -218,6 +217,35 @@ class TestHighLine < Minitest::Test
       q.case = :down
     end
     assert_equal("crazy", answer)
+  end
+
+  def test_ask_with_overwrite
+    @input << "Yes, sure!\n"
+    @input.rewind
+
+    answer = @terminal.ask("Do you like Ruby? ") do |q|
+      q.overwrite = true
+      q.echo      = false
+    end
+
+    assert_equal("Yes, sure!", answer)
+    erase_sequence = "\r#{HighLine.Style(:erase_line).code}"
+    assert_equal("Do you like Ruby? #{erase_sequence}", @output.string)
+  end
+
+  def test_ask_with_overwrite_and_character_mode
+    @input << "Y"
+    @input.rewind
+
+    answer = @terminal.ask("Do you like Ruby (Y/N)? ") do |q|
+      q.overwrite = true
+      q.echo      = false
+      q.character = true
+    end
+
+    assert_equal("Y", answer)
+    erase_sequence = "\r#{HighLine.Style(:erase_line).code}"
+    assert_equal("Do you like Ruby (Y/N)? #{erase_sequence}", @output.string)
   end
 
   def test_character_echo

--- a/test/test_import.rb
+++ b/test/test_import.rb
@@ -8,7 +8,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline/import"

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # coding: utf-8
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline/list"

--- a/test/test_menu.rb
+++ b/test/test_menu.rb
@@ -8,7 +8,6 @@
 #
 #  This is Free Software. See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_paginator.rb
+++ b/test/test_paginator.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # coding: utf-8
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_simulator.rb
+++ b/test/test_simulator.rb
@@ -1,4 +1,3 @@
-require "minitest/autorun"
 require "test_helper"
 
 require "highline/import"

--- a/test/test_string_extension.rb
+++ b/test/test_string_extension.rb
@@ -60,4 +60,13 @@ class TestStringExtension < Minitest::Test
       @string.unknown_message
     end
   end
+
+  def test_String_includes_StringExtension_when_receives_colorize_strings
+    @include_received = 0
+    caller = Proc.new { @include_received += 1 }
+    ::String.stub :include, caller do
+      HighLine.colorize_strings
+    end
+    assert_equal 1, @include_received
+  end
 end

--- a/test/test_string_extension.rb
+++ b/test/test_string_extension.rb
@@ -7,7 +7,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_string_extension.rb
+++ b/test/test_string_extension.rb
@@ -28,6 +28,10 @@ class TestStringExtension < Minitest::Test
     @string = FakeString.new "string"
   end
 
+  def teardown
+    HighLine.reset
+  end
+
   include StringMethods
 
   def test_Highline_String_is_yaml_serializable
@@ -40,6 +44,20 @@ class TestStringExtension < Minitest::Test
       assert_equal "Yaml didn't messed with HighLine::String", yaml_loaded_string
       assert_equal highline_string, yaml_loaded_string
       assert_instance_of HighLine::String, yaml_loaded_string
+    end
+  end
+
+  def test_highline_string_respond_to_color
+    assert HighLine::String.new("highline string").respond_to? :color
+  end
+
+  def test_normal_string_doesnt_respond_to_color
+    refute "normal_string".respond_to? :color
+  end
+
+  def test_highline_string_still_raises_for_non_available_messages
+    assert_raises(NoMethodError) do
+      @string.unknown_message
     end
   end
 end

--- a/test/test_string_highline.rb
+++ b/test/test_string_highline.rb
@@ -7,7 +7,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_style.rb
+++ b/test/test_style.rb
@@ -69,18 +69,28 @@ class TestStyle < Minitest::Test
     assert_nil s.list
     assert_equal "\e[1m", s.code
     assert_equal :bold, s.name
+    assert s.builtin
 
     # Create a builtin style from a new ANSI escape string
     s = HighLine.Style("\e[96m")
     assert_instance_of HighLine::Style, s
     assert_nil s.list
     assert_equal "\e[96m", s.code
+    assert s.builtin
+
+    # Create a non-builtin style from a string
+    s = HighLine.Style("\e[109m")
+    assert_instance_of HighLine::Style, s
+    assert_nil s.list
+    assert_equal "\e[109m", s.code
+    refute s.builtin
 
     # Create a builtin style from a symbol
     s = HighLine.Style(:red)
     assert_instance_of HighLine::Style, s
     assert_nil s.list
     assert_equal :red, s.name
+    assert s.builtin
 
     # Retrieve an existing style by name (no new Style created)
     s = HighLine.Style(@style2.name)

--- a/test/test_style.rb
+++ b/test/test_style.rb
@@ -7,7 +7,6 @@
 #
 #  This is Free Software.  See LICENSE and COPYING for details.
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline"

--- a/test/test_wrapper.rb
+++ b/test/test_wrapper.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # coding: utf-8
 
-require "minitest/autorun"
 require "test_helper"
 
 require "highline/wrapper"


### PR DESCRIPTION
This PR has some fixes for SimpleCov reporting. (It was reporting a wrong percentage because of simple cov loading sequence time issues - tests were loading before simplecov).

It also adds some tests more and makes some improvement in test coverage.
Before: 1144 / 1206 LOC (94.86%)
After: 1162 / 1206 LOC (96.35%)