### PR TITLE
Fix agree validation to only accept "yes" or "no"

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -190,7 +190,7 @@ class HighLine
   # @see Question#character
   def agree( yes_or_no_question, character = nil )
     ask(yes_or_no_question, lambda { |yn| yn.downcase[0] == ?y}) do |q|
-      q.validate                 = /\Ay(?:es)?|no?\Z/i
+      q.validate                 = /\A(?:y(?:es)?|no?)\Z/i
       q.responses[:not_valid]    = 'Please enter "yes" or "no".'
       q.responses[:ask_on_error] = :question
       q.character                = character

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -35,7 +35,7 @@ class TestHighLine < Minitest::Test
   end
   
   def test_agree
-    @input << "y\nyes\nYES\nHell no!\nNo\n"
+    @input << "y\nyes\nYES\nyuk\nHell no!\nNo\n"
     @input.rewind
 
     assert_equal(true, @terminal.agree("Yes or no?  "))

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -34,15 +34,55 @@ class TestHighLine < Minitest::Test
     @terminal = HighLine.new(@input, @output)  
   end
   
-  def test_agree
-    @input << "y\nyes\nYES\nyuk\nHell no!\nNo\n"
-    @input.rewind
+  def test_agree_valid_yes_answers
+    valid_yes_answers = %w{ y yes Y YES }
 
-    assert_equal(true, @terminal.agree("Yes or no?  "))
-    assert_equal(true, @terminal.agree("Yes or no?  "))
-    assert_equal(true, @terminal.agree("Yes or no?  "))
-    assert_equal(false, @terminal.agree("Yes or no?  "))
-    
+    valid_yes_answers.each do |user_input|
+      @input << "#{user_input}\n"
+      @input.rewind
+
+      assert_equal true, @terminal.agree("Yes or no?  ")
+      assert_equal "Yes or no?  ", @output.string
+
+      @input.truncate(@input.rewind)
+      @output.truncate(@output.rewind)
+    end
+  end
+
+  def test_agree_valid_no_answers
+    valid_no_answers = %w{ n no N NO }
+
+    valid_no_answers.each do |user_input|
+      @input << "#{user_input}\n"
+      @input.rewind
+
+      assert_equal false, @terminal.agree("Yes or no?  ")
+      assert_equal "Yes or no?  ", @output.string
+
+      @input.truncate(@input.rewind)
+      @output.truncate(@output.rewind)
+    end
+  end
+
+  def test_agree_invalid_answers
+    invalid_answers = [ "ye", "yuk", "nope", "Oh yes", "Oh no", "Hell no!"]
+
+    invalid_answers.each do |user_input|
+      # Each invalid answer, should be followed by a 'y' (as the question is reasked)
+      @input << "#{user_input}\ny\n"
+      @input.rewind
+
+      assert_equal true, @terminal.agree("Yes or no?  ")
+
+      # It reasks the question if the answer is invalid
+      assert_equal "Yes or no?  Please enter \"yes\" or \"no\".\nYes or no?  ", @output.string
+
+      @input.truncate(@input.rewind)
+      @output.truncate(@output.rewind)
+    end
+  end
+
+  def test_agree_with_getc
     @input.truncate(@input.rewind)
     @input << "yellow"
     @input.rewind


### PR DESCRIPTION
Although the documentation for `agree` states that it only accepts yes/no/y/n case-insensitively, the `Regexp` allowed any string which started with `/y/i` or ended with `/no?/i` and interpreted any starting with `'y'` as `true`.  This PR fixes the `Regexp` to properly exclude the start and end markers from the alternation and add a test value to confirm it works.

Thanks for considering,
Kevin