### PR TITLE
Make Travis ignore gems in development group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ matrix:
     - rvm: rbx-2
     - rvm: jruby-19mode # JRuby in 1.9 mode
     - rvm: jruby-head
+bundler_args: --without development


### PR DESCRIPTION
Trying to recover from last Travis fail while speeding up it bypassing the development group gems of Gemfile.