### PR TITLE
confirm in question now accepts Proc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+* PR #201 - Confirm in question now accepts Proc
+
 * PR #197 - Some HighLine::Menu improvements
   * Move Menu::MenuItem to Menu::Item with its own file
   * Some small refactorings

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -147,11 +147,15 @@ class HighLine
     attr_accessor :in
     #
     # Asks a yes or no confirmation question, to ensure a user knows what
-    # they have just agreed to.  If set to +true+ the question will be,
-    # "Are you sure?  "  Any other true value for this attribute is assumed
-    # to be the question to ask.  When +false+ or +nil+ (the default),
-    # answers are not confirmed.
-    #
+    # they have just agreed to.  The confirm attribute can be set to :
+    # +true+  :     In this case the question will be, "Are you sure?". 
+    # Proc    :     The Proc is yielded the answer given. The Proc must 
+    #               output a string which is then used as the confirm 
+    #               question. 
+    # String  :     The String must use ERB syntax. The String is 
+    #               evaluated with with access to question and answer and
+    #               is then used as the confirm question.
+    # When set to +false+ or +nil+ (the default), answers are not confirmed.
     attr_accessor :confirm
     #
     # When set, the user will be prompted for multiple answers which will

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -153,7 +153,7 @@ class HighLine
     #               output a string which is then used as the confirm 
     #               question. 
     # String  :     The String must use ERB syntax. The String is 
-    #               evaluated with with access to question and answer and
+    #               evaluated with access to question and answer and
     #               is then used as the confirm question.
     # When set to +false+ or +nil+ (the default), answers are not confirmed.
     attr_accessor :confirm

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -529,6 +529,8 @@ class HighLine
     def confirm_question(highline)
       if confirm == true
         "Are you sure?  "
+      elsif confirm.is_a?(Proc)
+        confirm.call(self.answer)
       else
         # evaluate ERb under initial scope, so it will have
         # access to question and answer

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -579,6 +579,24 @@ class TestHighLine < Minitest::Test
     assert_equal( "Enter a filename:  " +
                   "Are you sure you want to overwrite junk.txt?  ",
                   @output.string )
+
+    @input.truncate(@input.rewind)
+    @input << "junk.txt\nyes\nsave.txt\nn\n"
+    @input.rewind
+    @output.truncate(@output.rewind)
+
+    scoped_variable = { "junk.txt" => '20mb' }
+    answer = @terminal.ask("Enter a filename:  ") do |q|
+      q.confirm = Proc.new do |answer| 
+        "Are you sure you want to overwrite #{answer} with size " +
+         "of #{scoped_variable[answer]}? "
+      end
+    end
+    assert_equal("junk.txt", answer)
+    assert_equal( "Enter a filename:  " +
+                  "Are you sure you want to overwrite junk.txt " +
+                  "with size of 20mb? ",
+                  @output.string )
   end
   
   def test_generic_confirm_with_true


### PR DESCRIPTION
Implemented functionality to assign a Proc object to the confirm attribute of the Highline::Question object.
