### PR TITLE
Show default value in menu 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cli.choose do |menu|
   menu.prompt = "Please choose your favorite programming language?  "
   menu.choice(:ruby) { cli.say("Good choice!") }
   menu.choices(:python, :perl) { cli.say("Not from around here, are you?") }
+  menu.default = :ruby
 end
 
 ## Using colored indices on Menus

--- a/examples/menus.rb
+++ b/examples/menus.rb
@@ -26,6 +26,9 @@ choose do |menu|
 
   menu.choice :ruby do say("Good choice!") end
   menu.choices(:python, :perl) do say("Not from around here, are you?") end
+
+  menu.default = :ruby
+
 end
 
 say("\nThis is letter indexing...")

--- a/lib/highline/menu.rb
+++ b/lib/highline/menu.rb
@@ -516,21 +516,31 @@ class HighLine
       case @layout
       when :list
         %(<%= header ? "#{header}:\n" : '' %>) +
-        "<%= list( menu, #{@flow.inspect},
-                          #{@list_option.inspect} ) %>" +
+        parse_list +
+        show_default_if_any + 
         "<%= prompt %>"
       when :one_line
         %(<%= header ? "#{header}:  " : '' %>) +
         "<%= prompt %>" +
-        "(<%= list( menu, #{@flow.inspect},
-                           #{@list_option.inspect} ) %>)" +
+        "(" + parse_list + ")" +
+        show_default_if_any +
         "<%= prompt[/\s*$/] %>"
       when :menu_only
-        "<%= list( menu, #{@flow.inspect},
-                          #{@list_option.inspect} ) %><%= prompt %>"
+        parse_list +
+        show_default_if_any +
+        "<%= prompt %>"
       else
         @layout
       end
+    end
+
+    def parse_list
+      "<%= list( menu, #{@flow.inspect},
+           #{@list_option.inspect} ) %>" 
+    end
+
+    def show_default_if_any
+      return !@default.to_s.empty? ? "(#{@default}) " : ""
     end
 
     #

--- a/lib/highline/menu.rb
+++ b/lib/highline/menu.rb
@@ -540,7 +540,7 @@ class HighLine
     end
 
     def show_default_if_any
-      return !@default.to_s.empty? ? "(#{@default}) " : ""
+      return default.to_s.empty? ? "" : "(#{default}) "
     end
 
     #

--- a/test/test_menu.rb
+++ b/test/test_menu.rb
@@ -31,6 +31,18 @@ class TestMenu < Minitest::Test
     assert_equal("Sample2", output)
   end
 
+  def test_default
+    @input << "\n"
+    @input.rewind
+
+    output = @terminal.choose do |menu|
+      menu.choices("Sample1", "Sample2", "Sample3")
+      menu.default = "Sample1"
+    end
+
+    assert_equal("Sample1", output)
+  end
+
   def test_flow
     @input << "Sample1\n"
     @input.rewind


### PR DESCRIPTION
Default option behaviour was already implemented, but not properly shown. The unit test added in this PR confirms this. (refer to #191). 

![image](https://cloud.githubusercontent.com/assets/6811076/16719488/49530cf4-4701-11e6-94f0-f50dcf762878.png)

This appends the default value to the prompt, like in the image above. 