### PR TITLE
Do not attempt to change frozen strings

### DIFF
--- a/lib/highline/simulate.rb
+++ b/lib/highline/simulate.rb
@@ -23,7 +23,7 @@ class HighLine
 
     # Simulate StringIO#getbyte by shifting a single character off of the next line of the script
     def getbyte
-      line = gets
+      line = gets.dup
       if line.length > 0
         char = line.slice! 0
         @strings.unshift line

--- a/test/tc_simulator.rb
+++ b/test/tc_simulator.rb
@@ -20,4 +20,14 @@ class SimulatorTest < Test::Unit::TestCase
       assert_equal '18', age
     end
   end
+
+  def test_simulate_with_echo_and_frozen_strings
+    HighLine::Simulate.with('the password'.freeze) do
+      password = ask('What is your password?') do |q|
+        q.echo = '*'
+      end
+
+      assert_equal 'the password', password
+    end
+  end
 end


### PR DESCRIPTION
On Ruby 2.3+ string literals are frozen by default. This causes problems
in `HighLine::Simulate` since it will try to `.slice!` a frozen string
when the default `echo` has been changed.