### PR TITLE
Add method to reset use_color setting.

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,9 +44,6 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
-  # The setting used to disable color output.
-  @use_color = true
-
   # Pass +false+ to _setting_ to turn off HighLine's color escapes.
   def self.use_color=( setting )
     @use_color = setting
@@ -56,6 +53,14 @@ class HighLine
   def self.use_color?
     @use_color
   end
+
+  # Resets the use of color.
+  def self.reset_use_color
+    @use_color = true
+  end
+
+  # Use color output by default.
+  reset_use_color
 
   # For checking if the current version of HighLine supports RGB colors
   # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
@@ -101,10 +106,11 @@ class HighLine
   end
 
   # Reset HighLine to default.
-  # Clears Style index and reset color scheme.
+  # Clears Style index and resets color_scheme and use_color settings.
   def self.reset
     Style.clear_index
     reset_color_scheme
+    reset_use_color
   end
 
   # Reset color scheme to default (+nil+)

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -507,6 +507,13 @@ class TestHighLine < Minitest::Test
     HighLine.use_color = old_setting
   end
 
+  def test_reset_use_color
+    HighLine.use_color = false
+    refute HighLine.use_color?
+    HighLine.reset_use_color
+    assert HighLine.use_color?
+  end
+
   def test_uncolor
     # instance method
     assert_equal( "This should be reverse underlined magenta!\n",


### PR DESCRIPTION
We ran into some order dependent test failures because some tests were setting `HighLine.use_color` and not resetting it in between test runs. When we figured out the problem, we reset the value in a before block for our rspec suite. Since we need to change HighLine's color setting and there was no easy way to reset it, it seemed like a good addition to the `reset` method.

Before we had to do something like this:

```
before do
  @old_highline_use_color = HighLine.use_color?
  HighLine.use_color = true
end

after do
  HighLine.use_color = @old_highline_use_color
end
```

After this PR we would only have to do:

```
before do
  HighLine.reset
end
```