### PR TITLE
Make use_color= and use_color? instance methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: ruby
 sudo: false
-script: "bundle exec rake test"
+script: "bundle exec rake test && bundle exec codeclimate-test-reporter"
 rvm:
   - 1.9
   - 2.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+### 2.0.0-develop.9 / 2017-06-24
+
+* PR #211 / PR #212 - HighLine#use_color= and use_color? as instance methods (@abinoam, @phiggins)
 * PR #203 / I #191 - Default values are shown in menus by Frederico (@fredrb)
 * PR #201 / I #198 - Confirm in question now accepts Proc (@mmihira)
 * PR #197 - Some HighLine::Menu improvements

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -146,6 +146,7 @@ class HighLine
     @header   = nil
     @prompt   = nil
     @key      = nil
+    @use_color = true
 
     @terminal = HighLine::Terminal.get_terminal(input, output)
   end

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -310,9 +310,11 @@ class HighLine
   end
 
   # (see .color)
-  # Convenience instance method. It delegates to the class method.
+  # This method is a clone of the HighLine.color class method.
+  # But it checks for use_color? per instance
   def color(string, *colors)
-    self.class.color(string, *colors)
+    return string unless use_color?
+    Style(*colors).color(string)
   end
 
   # In case you just want the color code, without the embedding and

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -52,6 +52,14 @@ class HighLine
     @use_color
   end
 
+  # Resets the use of color.
+  def self.reset_use_color
+    @use_color = true
+  end
+
+  # Use color output by default.
+  reset_use_color
+
   # For checking if the current version of HighLine supports RGB colors
   # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
   # Note: color usage also depends on HighLine.use_color being set
@@ -96,10 +104,11 @@ class HighLine
   end
 
   # Reset HighLine to default.
-  # Clears Style index and reset color scheme.
+  # Clears Style index and resets color_scheme and use_color settings.
   def self.reset
     Style.clear_index
     reset_color_scheme
+    reset_use_color
   end
 
   # Reset color scheme to default (+nil+)

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -52,6 +52,9 @@ class HighLine
     @use_color = setting
   end
 
+  # Set it to false to disable ANSI coloring
+  attr_writer :use_color
+
   # Returns true if HighLine is currently using color escapes.
   def self.use_color?
     @use_color

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -319,7 +319,7 @@ class HighLine
   # But it checks for use_color? per instance
   def color(string, *colors)
     return string unless use_color?
-    Style(*colors).color(string)
+    HighLine.Style(*colors).color(string)
   end
 
   # In case you just want the color code, without the embedding and

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,12 +44,9 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
-  # The setting used to disable color output.
-  @use_color = true
-
   # Pass +false+ to _setting_ to turn off HighLine's color escapes.
   def self.use_color=( setting )
-    @use_color = setting
+    $terminal.use_color = setting
   end
 
   # Set it to false to disable ANSI coloring
@@ -57,7 +54,7 @@ class HighLine
 
   # Returns true if HighLine is currently using color escapes.
   def self.use_color?
-    @use_color
+    $terminal.use_color?
   end
 
   # Returns true if HighLine instance is currently using color escapes.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -53,12 +53,9 @@ class HighLine
   end
 
   # Resets the use of color.
-  def self.reset_use_color
+  def reset_use_color
     @use_color = true
   end
-
-  # Use color output by default.
-  reset_use_color
 
   # For checking if the current version of HighLine supports RGB colors
   # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,18 +44,8 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
-  # Pass +false+ to _setting_ to turn off HighLine's color escapes.
-  def self.use_color=( setting )
-    $terminal.use_color = setting
-  end
-
   # Set it to false to disable ANSI coloring
   attr_writer :use_color
-
-  # Returns true if HighLine is currently using color escapes.
-  def self.use_color?
-    $terminal.use_color?
-  end
 
   # Returns true if HighLine instance is currently using color escapes.
   def use_color?

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -60,6 +60,11 @@ class HighLine
     @use_color
   end
 
+  # Returns true if HighLine instance is currently using color escapes.
+  def use_color?
+    @use_color
+  end
+
   # For checking if the current version of HighLine supports RGB colors
   # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
   # Note: color usage also depends on HighLine.use_color being set

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -24,7 +24,8 @@ $terminal = HighLine.new
 #
 module Kernel
   extend Forwardable
-  def_delegators :$terminal, :agree, :ask, :choose, :say
+  def_delegators :$terminal, :agree, :ask, :choose, :say,
+                 :use_color=, :use_color?, :reset_use_color
 end
 
 # When requiring 'highline/import' HighLine adds {#or_ask} to Object so
@@ -46,22 +47,5 @@ class Object
 
       details.call(question) if details
     end
-  end
-end
-
-class HighLine
-  # Pass +false+ to _setting_ to turn off HighLine's color escapes.
-  def self.use_color=(setting)
-    $terminal.use_color = setting
-  end
-
-  # Returns true if HighLine is currently using color escapes.
-  def self.use_color?
-    $terminal.use_color?
-  end
-
-  # Resets the use of color.
-  def self.reset_use_color
-    $terminal.reset_use_color
   end
 end

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -59,4 +59,9 @@ class HighLine
   def self.use_color?
     $terminal.use_color?
   end
+
+  # Resets the use of color.
+  def self.reset_use_color
+    $terminal.reset_use_color
+  end
 end

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -48,3 +48,15 @@ class Object
     end
   end
 end
+
+class HighLine
+  # Pass +false+ to _setting_ to turn off HighLine's color escapes.
+  def self.use_color=(setting)
+    $terminal.use_color = setting
+  end
+
+  # Returns true if HighLine is currently using color escapes.
+  def self.use_color?
+    $terminal.use_color?
+  end
+end

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -2,5 +2,5 @@
 
 class HighLine
   # The version of the installed library.
-  VERSION = "2.0.0-develop.8".freeze
+  VERSION = "2.0.0-develop.9".freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,11 +3,6 @@
 
 require 'simplecov'
 
-if ENV['CODECLIMATE_REPO_TOKEN']
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
-end
-
 # Compatibility module for StringIO, File
 # and Tempfile. Necessary for some tests.
 require "io_console_compatible"

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -515,6 +515,7 @@ class TestHighLine < Minitest::Test
     old_setting = HighLine.use_color?
     cli = HighLine.new(cli_input, cli_output)
 
+    # Testing with both use_color setted to true
     HighLine.use_color = true
     cli.use_color = true
 
@@ -523,6 +524,19 @@ class TestHighLine < Minitest::Test
 
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", cli_output.string)
+
+    @output.truncate(@output.rewind)
+    cli_output.truncate(cli_output.rewind)
+
+    # Testing with both use_color setted to false
+    HighLine.use_color = false
+    cli.use_color = false
+
+    @terminal.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", @output.string)
+
+    cli.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", cli_output.string)
 
     HighLine.use_color = old_setting
   end

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -507,6 +507,15 @@ class TestHighLine < Minitest::Test
     HighLine.use_color = old_setting
   end
 
+  def test_color_setting_per_instance
+    # It can set coloring at HighLine class
+    old_setting = HighLine.use_color?
+    HighLine.use_color = true
+    @terminal.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", @output.string)
+    HighLine.use_color = old_setting
+  end
+
   def test_uncolor
     # instance method
     assert_equal( "This should be reverse underlined magenta!\n",

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -603,6 +603,13 @@ class TestHighLine < Minitest::Test
     $terminal = old_glob_term
   end
 
+  def test_reset_use_color
+    HighLine.use_color = false
+    refute HighLine.use_color?
+    HighLine.reset_use_color
+    assert HighLine.use_color?
+  end
+
   def test_uncolor
     # instance method
     assert_equal( "This should be reverse underlined magenta!\n",

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -502,9 +502,11 @@ class TestHighLine < Minitest::Test
     # turn off color
     old_setting = HighLine.use_color?
     HighLine.use_color = false
+    @terminal.use_color = false
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", @output.string)
     HighLine.use_color = old_setting
+    @terminal.use_color = old_setting
   end
 
   def test_color_setting_per_instance
@@ -517,6 +519,7 @@ class TestHighLine < Minitest::Test
 
     # Testing with both use_color setted to true
     HighLine.use_color = true
+    @terminal.use_color = true
     cli.use_color = true
 
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
@@ -530,6 +533,7 @@ class TestHighLine < Minitest::Test
 
     # Testing with both use_color setted to false
     HighLine.use_color = false
+    @terminal.use_color = false
     cli.use_color = false
 
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
@@ -545,6 +549,7 @@ class TestHighLine < Minitest::Test
 
     # Class false, instance true
     HighLine.use_color = false
+    @terminal.use_color = false
     cli.use_color = true
 
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
@@ -558,6 +563,7 @@ class TestHighLine < Minitest::Test
 
     # Class true, instance false
     HighLine.use_color = true
+    @terminal.use_color = true
     cli.use_color = false
 
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
@@ -570,6 +576,7 @@ class TestHighLine < Minitest::Test
     cli_output.truncate(cli_output.rewind)
 
     HighLine.use_color = old_setting
+    @terminal.use_color = old_setting
   end
 
   def test_uncolor

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -610,6 +610,13 @@ class TestHighLine < Minitest::Test
     assert HighLine.use_color?
   end
 
+  def test_reset_use_color_when_highline_reset
+    HighLine.use_color = false
+    refute HighLine.use_color?
+    HighLine.reset
+    assert HighLine.use_color?
+  end
+
   def test_uncolor
     # instance method
     assert_equal( "This should be reverse underlined magenta!\n",

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -510,11 +510,18 @@ class TestHighLine < Minitest::Test
   end
 
   def test_color_setting_per_instance
+    require 'highline/import'
+    old_glob_term = $terminal
+    old_setting = HighLine.use_color?
+
+    gterm_input = StringIO.new
+    gterm_output = StringIO.new
+    $terminal = HighLine.new(gterm_input, gterm_output)
+
     # It can set coloring at HighLine class
     cli_input = StringIO.new
     cli_output = StringIO.new
 
-    old_setting = HighLine.use_color?
     cli = HighLine.new(cli_input, cli_output)
 
     # Testing with both use_color setted to true
@@ -522,12 +529,16 @@ class TestHighLine < Minitest::Test
     @terminal.use_color = true
     cli.use_color = true
 
+    say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", gterm_output.string)
+
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", @output.string)
 
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", cli_output.string)
 
+    gterm_output.truncate(gterm_output.rewind)
     @output.truncate(@output.rewind)
     cli_output.truncate(cli_output.rewind)
 
@@ -536,12 +547,16 @@ class TestHighLine < Minitest::Test
     @terminal.use_color = false
     cli.use_color = false
 
+    say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", gterm_output.string)
+
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", @output.string)
 
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", cli_output.string)
 
+    gterm_output.truncate(gterm_output.rewind)
     @output.truncate(@output.rewind)
     cli_output.truncate(cli_output.rewind)
 
@@ -552,12 +567,16 @@ class TestHighLine < Minitest::Test
     @terminal.use_color = false
     cli.use_color = true
 
+    say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", gterm_output.string)
+
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", @output.string)
 
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", cli_output.string)
 
+    gterm_output.truncate(gterm_output.rewind)
     @output.truncate(@output.rewind)
     cli_output.truncate(cli_output.rewind)
 
@@ -566,17 +585,22 @@ class TestHighLine < Minitest::Test
     @terminal.use_color = true
     cli.use_color = false
 
+    say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", gterm_output.string)
+
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", @output.string)
 
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", cli_output.string )
 
+    gterm_output.truncate(gterm_output.rewind)
     @output.truncate(@output.rewind)
     cli_output.truncate(cli_output.rewind)
 
     HighLine.use_color = old_setting
     @terminal.use_color = old_setting
+    $terminal = old_glob_term
   end
 
   def test_uncolor

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -509,10 +509,21 @@ class TestHighLine < Minitest::Test
 
   def test_color_setting_per_instance
     # It can set coloring at HighLine class
+    cli_input = StringIO.new
+    cli_output = StringIO.new
+
     old_setting = HighLine.use_color?
+    cli = HighLine.new(cli_input, cli_output)
+
     HighLine.use_color = true
+    cli.use_color = true
+
     @terminal.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be \e[36mcyan\e[0m!\n", @output.string)
+
+    cli.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", cli_output.string)
+
     HighLine.use_color = old_setting
   end
 

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -538,6 +538,37 @@ class TestHighLine < Minitest::Test
     cli.say("This should be <%= color('cyan', CYAN) %>!")
     assert_equal("This should be cyan!\n", cli_output.string)
 
+    @output.truncate(@output.rewind)
+    cli_output.truncate(cli_output.rewind)
+
+    # Now check when class and instance doesn't agree about use_color
+
+    # Class false, instance true
+    HighLine.use_color = false
+    cli.use_color = true
+
+    @terminal.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", @output.string)
+
+    cli.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", cli_output.string)
+
+    @output.truncate(@output.rewind)
+    cli_output.truncate(cli_output.rewind)
+
+    # Class true, instance false
+    HighLine.use_color = true
+    cli.use_color = false
+
+    @terminal.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be \e[36mcyan\e[0m!\n", @output.string)
+
+    cli.say("This should be <%= color('cyan', CYAN) %>!")
+    assert_equal("This should be cyan!\n", cli_output.string )
+
+    @output.truncate(@output.rewind)
+    cli_output.truncate(cli_output.rewind)
+
     HighLine.use_color = old_setting
   end
 


### PR DESCRIPTION
This PR solves the issues commented by @phiggins at PR #211.
Basically it shifts the responsability about `use_color` to the HighLine instance.
And do some convolution to try to maintain back compatibility.

After this PR is possible to have something like this.

```ruby
require 'highline'

colored_cli = HighLine.new
uncolored_cli = HighLine.new

colored_cli.use_color = true # This is the default
uncolored_cli.use_color = false

colored_cli.say("This should be <%= color('red', RED) %>")
uncolored_cli.say("This should NOT be <%= color('red', RED) %>")
```

This is important at tests. If you're using a HighLine instance, just discard it and instantiate a new one so the tests could run in isolation.