### PR TITLE
Update some travis and appveyor settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+dist: trusty
 sudo: false
 script: "bundle exec rake test && bundle exec codeclimate-test-reporter"
 rvm:
@@ -9,7 +10,7 @@ rvm:
   - 2.2
   - 2.3.0
   - ruby-head
-  - rbx-2
+  - rbx-3.81
   - jruby-19mode # JRuby in 1.9 mode
   - jruby-head
 
@@ -19,7 +20,7 @@ matrix:
   allow_failures:
     - rvm: 1.9
     - rvm: ruby-head
-    - rvm: rbx-2
+    - rvm: rbx-3.81
     - rvm: jruby-19mode # JRuby in 1.9 mode
     - rvm: jruby-head
 bundler_args: --without development

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@
 language: ruby
 dist: trusty
 sudo: false
-script: "bundle exec rake test && bundle exec codeclimate-test-reporter"
+script: "bundle exec rake test"
 rvm:
   - 1.9
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
   - ruby-head
   - rbx-3.81
   - jruby-19mode # JRuby in 1.9 mode
@@ -23,4 +22,7 @@ matrix:
     - rvm: rbx-3.81
     - rvm: jruby-19mode # JRuby in 1.9 mode
     - rvm: jruby-head
+  include:
+    - rvm: 2.3
+      script: "bundle exec rake test && bundle exec codeclimate-test-reporter" # Run only for 2.3
 bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,14 @@ group :development, :test do
   gem "minitest", require: false
 end
 
+
+# Reporting only at one ruby version of travis matrix (no repetition)
 gem "codeclimate-test-reporter", group: :test, require: false
-gem "simplecov", group: :test, require: false
+
+platform :ruby do
+  # Running only on MRI
+  gem "simplecov", group: :test
+end
 
 group :development do
   gem 'pronto'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - gem install bundler --no-document -v 1.10.5
-  - bundle install --retry=3
+  - bundle install --retry=3 --without development
 
 test_script:
   - bundle exec rake

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # coding: utf-8
 
-require 'simplecov'
+# Run code coverage only for mri
+require 'simplecov' if RUBY_ENGINE == 'ruby'
 
 # Compatibility module for StringIO, File
 # and Tempfile. Necessary for some tests.


### PR DESCRIPTION
* Run simplecov (code coverage) only for mri. Problems with rbx and windows.
* Report code coverage to codeclimate only once per build. Avoid repetitive reporting.
* Update to dist: trusty so we can run rbx tests on travis
* Avoid installing pronto (development group) on windows (appveyor). Incompatible.