### PR TITLE
Remove the use of $terminal global variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+### 2.0.0-develop.10 / 2017-06-29
+* PR #214 - Remove `$terminal` (global variable)
+  * Use HighLine.default_instance instead
+  * Reorganize/Group code at lib/highline.rb
+
 ### 2.0.0-develop.9 / 2017-06-24
 
 * PR #211 / PR #212 - HighLine#use_color= and use_color? as instance methods (@abinoam, @phiggins)

--- a/examples/asking_for_arrays.rb
+++ b/examples/asking_for_arrays.rb
@@ -9,7 +9,7 @@ require "rubygems"
 require "highline/import"
 require "pp"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.class}"
 puts
 
 grades = ask( "Enter test scores (or a blank line to quit):",

--- a/examples/basic_usage.rb
+++ b/examples/basic_usage.rb
@@ -9,7 +9,7 @@ require "rubygems"
 require "highline/import"
 require "yaml"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 contacts = [ ]

--- a/examples/get_character.rb
+++ b/examples/get_character.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 require "highline/import"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 choices = "ynaq"

--- a/examples/limit.rb
+++ b/examples/limit.rb
@@ -8,7 +8,7 @@
 require "rubygems"
 require "highline/import"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 text = ask("Enter text (max 10 chars): ") { |q| q.limit = 10 }

--- a/examples/menus.rb
+++ b/examples/menus.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 require "highline/import"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 # The old way, using ask() and say()...

--- a/examples/overwrite.rb
+++ b/examples/overwrite.rb
@@ -8,7 +8,7 @@
 require 'rubygems'
 require 'highline/import'
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 prompt = "here is your password:"

--- a/examples/page_and_wrap.rb
+++ b/examples/page_and_wrap.rb
@@ -8,8 +8,8 @@
 require "rubygems"
 require "highline/import"
 
-$terminal.wrap_at = 80
-$terminal.page_at = 22
+HighLine.default_instance.wrap_at = 80
+HighLine.default_instance.page_at = 22
 
 say(<<END)
 THE UNITED STATES CONSTITUTION

--- a/examples/password.rb
+++ b/examples/password.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 require "highline/import"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 pass = ask("Enter your password:  ") { |q| q.echo = false }

--- a/examples/repeat_entry.rb
+++ b/examples/repeat_entry.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 require "highline/import"
 
-puts "Using: #{$terminal.terminal.class}"
+puts "Using: #{HighLine.default_instance.terminal.class}"
 puts
 
 tounge_twister = ask("... try saying that three times fast") do |q|

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -51,13 +51,7 @@ class HighLine
                         :color, :uncolor, :color_code
 
   class << self
-    def default_instance
-      @default_instance
-    end
-
-    def default_instance=(highline_instance)
-      @default_instance = highline_instance
-    end
+    attr_accessor :default_instance
   end
 
   # Set it to false to disable ANSI coloring

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -46,7 +46,8 @@ class HighLine
 
   extend SingleForwardable
   def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
-                        :use_color=, :use_color?, :reset_use_color
+                        :use_color=, :use_color?, :reset_use_color,
+                        :track_eof=, :track_eof?
 
   def self.default_instance
     @default_instance
@@ -77,21 +78,11 @@ class HighLine
   end
 
   # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
-  def self.track_eof=(setting)
-    default_instance.track_eof=(setting)
-  end
-
-  # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
   def track_eof=(setting)
     @track_eof = setting
   end
 
   # Returns true if HighLine is currently tracking EOF for input.
-  def self.track_eof?
-    default_instance.track_eof?
-  end
-
-  # (see HighLine.track_eof?)
   def track_eof?
     @track_eof
   end

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -341,15 +341,8 @@ class HighLine
   # Remove color codes from a string.
   # @param string [String] to be decolorized
   # @return [String] without the ANSI escape sequence (colors)
-  def self.uncolor(string)
-    Style.uncolor(string)
-  end
-
-  # (see .uncolor)
-  # Convenience instance method. It delegates to the class method.
-
   def uncolor(string)
-    self.class.uncolor(string)
+    Style.uncolor(string)
   end
 
   # Renders a list of itens using a {ListRenderer}

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -99,14 +99,12 @@ class HighLine
     @use_color = true
   end
 
-  # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
-  def track_eof=(setting)
-    @track_eof = setting
-  end
+  # Pass +false+ to turn off HighLine's EOF tracking.
+  attr_accessor :track_eof
 
   # Returns true if HighLine is currently tracking EOF for input.
   def track_eof?
-    @track_eof
+    !!track_eof
   end
 
   #

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -61,6 +61,11 @@ class HighLine
       !!@color_scheme
     end
 
+    # Reset color scheme to default (+nil+)
+    def reset_color_scheme
+      self.color_scheme = nil
+    end
+
     # Reset HighLine to default.
     # Clears Style index and resets color_scheme and use_color settings.
     def reset
@@ -102,11 +107,6 @@ class HighLine
   # Returns true if HighLine is currently tracking EOF for input.
   def track_eof?
     @track_eof
-  end
-
-  # Reset color scheme to default (+nil+)
-  def self.reset_color_scheme
-    self.color_scheme = nil
   end
 
   #

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -56,6 +56,11 @@ class HighLine
     # Pass ColorScheme to set a HighLine color scheme.
     attr_accessor :color_scheme
 
+    # Returns +true+ if HighLine is currently using a color scheme.
+    def using_color_scheme?
+      !!@color_scheme
+    end
+
     # For checking if the current version of HighLine supports RGB colors
     # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
     # Note: color usage also depends on HighLine.use_color being set
@@ -89,11 +94,6 @@ class HighLine
   # Returns true if HighLine is currently tracking EOF for input.
   def track_eof?
     @track_eof
-  end
-
-  # Returns +true+ if HighLine is currently using a color scheme.
-  def self.using_color_scheme?
-    !!@color_scheme
   end
 
   # Reset HighLine to default.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -47,7 +47,7 @@ class HighLine
   extend SingleForwardable
   def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
                         :use_color=, :use_color?, :reset_use_color,
-                        :track_eof=, :track_eof?
+                        :track_eof=, :track_eof?, :color
 
   def self.default_instance
     @default_instance
@@ -300,23 +300,20 @@ class HighLine
   # (:blue for BLUE, for example).  A CLEAR will automatically be embedded to
   # the end of the returned String.
   #
-  # This method returns the original _string_ unchanged if HighLine::use_color?
+  # This method returns the original _string_ unchanged if use_color?
   # is +false+.
   #
   # @param string [String] string to be colored
   # @param colors [Array<Symbol>] array of colors like [:red, :blue]
   # @return [String] (ANSI escaped) colored string
   # @example
-  #    HighLine.color("Sustainable", :green, :bold)
+  #    cli = HighLine.new
+  #    cli.color("Sustainable", :green, :bold)
   #    # => "\e[32m\e[1mSustainable\e[0m"
-  def self.color( string, *colors )
-    return string unless self.use_color?
-    Style(*colors).color(string)
-  end
-
-  # (see .color)
-  # This method is a clone of the HighLine.color class method.
-  # But it checks for use_color? per instance
+  #
+  #    # As class method (delegating to HighLine.default_instance)
+  #    HighLine.color("Sustainable", :green, :bold)
+  #
   def color(string, *colors)
     return string unless use_color?
     HighLine.Style(*colors).color(string)

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -69,7 +69,12 @@ class HighLine
   end
 
   # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
-  def self.track_eof=( setting )
+  def self.track_eof=(setting)
+    default_instance.track_eof=(setting)
+  end
+
+  # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
+  def track_eof=(setting)
     @track_eof = setting
   end
 

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -78,12 +78,12 @@ class HighLine
 
   # Returns true if HighLine is currently tracking EOF for input.
   def self.track_eof?
-    @track_eof
+    default_instance.track_eof?
   end
 
   # (see HighLine.track_eof?)
   def track_eof?
-    self.class.track_eof?
+    @track_eof
   end
 
   # The setting used to control color schemes.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -53,22 +53,15 @@ class HighLine
   class << self
     attr_accessor :default_instance
 
+    # Pass ColorScheme to set a HighLine color scheme.
+    attr_accessor :color_scheme
+
     # For checking if the current version of HighLine supports RGB colors
     # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
     # Note: color usage also depends on HighLine.use_color being set
     # TODO: Discuss removing this method
     def supports_rgb_color?
       true
-    end
-
-    # Pass ColorScheme to _setting_ to set a HighLine color scheme.
-    def color_scheme=( setting )
-      @color_scheme = setting
-    end
-
-    # Returns the current color scheme.
-    def color_scheme
-      @color_scheme
     end
   end
 

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,8 +44,6 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
-  @default_instance = new
-
   extend SingleForwardable
   def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
                         :use_color=, :use_color?, :reset_use_color
@@ -646,6 +644,8 @@ class HighLine
   def actual_length(text)
     Wrapper.actual_length text
   end
+
+  @default_instance = new
 end
 
 require "highline/string"

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,8 +44,14 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
+  @default_instance = new
+
+  extend SingleForwardable
+  def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
+                        :use_color=, :use_color?, :reset_use_color
+
   def self.default_instance
-    @default_instance ||= new
+    @default_instance
   end
 
   def self.default_instance=(highline_instance)

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -61,6 +61,14 @@ class HighLine
       !!@color_scheme
     end
 
+    # Reset HighLine to default.
+    # Clears Style index and resets color_scheme and use_color settings.
+    def reset
+      Style.clear_index
+      reset_color_scheme
+      reset_use_color
+    end
+
     # For checking if the current version of HighLine supports RGB colors
     # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
     # Note: color usage also depends on HighLine.use_color being set
@@ -94,14 +102,6 @@ class HighLine
   # Returns true if HighLine is currently tracking EOF for input.
   def track_eof?
     @track_eof
-  end
-
-  # Reset HighLine to default.
-  # Clears Style index and resets color_scheme and use_color settings.
-  def self.reset
-    Style.clear_index
-    reset_color_scheme
-    reset_use_color
   end
 
   # Reset color scheme to default (+nil+)

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -644,8 +644,8 @@ class HighLine
   def actual_length(text)
     Wrapper.actual_length text
   end
-
-  @default_instance = new
 end
+
+HighLine.default_instance = HighLine.new
 
 require "highline/string"

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -68,9 +68,6 @@ class HighLine
     true
   end
 
-  # The setting used to disable EOF tracking.
-  @track_eof = true
-
   # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.
   def self.track_eof=( setting )
     @track_eof = setting
@@ -144,6 +141,7 @@ class HighLine
     @prompt   = nil
     @key      = nil
     @use_color = true
+    @track_eof = true # The setting used to disable EOF tracking.
 
     @terminal = HighLine::Terminal.get_terminal(input, output)
   end

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -87,11 +87,11 @@ class HighLine
   @color_scheme = nil
 
   # Set it to false to disable ANSI coloring
-  attr_writer :use_color
+  attr_accessor :use_color
 
-  # Returns true if HighLine instance is currently using color escapes.
+  # Returns truethy if HighLine instance is currently using color escapes.
   def use_color?
-    @use_color
+    !!use_color
   end
 
   # Resets the use of color.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -86,27 +86,6 @@ class HighLine
   # The setting used to control color schemes.
   @color_scheme = nil
 
-  # Set it to false to disable ANSI coloring
-  attr_accessor :use_color
-
-  # Returns truethy if HighLine instance is currently using color escapes.
-  def use_color?
-    !!use_color
-  end
-
-  # Resets the use of color.
-  def reset_use_color
-    @use_color = true
-  end
-
-  # Pass +false+ to turn off HighLine's EOF tracking.
-  attr_accessor :track_eof
-
-  # Returns true if HighLine is currently tracking EOF for input.
-  def track_eof?
-    !!track_eof
-  end
-
   #
   # Create an instance of HighLine connected to the given _input_
   # and _output_ streams.
@@ -137,6 +116,27 @@ class HighLine
     @track_eof = true # The setting used to disable EOF tracking.
 
     @terminal = HighLine::Terminal.get_terminal(input, output)
+  end
+
+  # Set it to false to disable ANSI coloring
+  attr_accessor :use_color
+
+  # Returns truethy if HighLine instance is currently using color escapes.
+  def use_color?
+    !!use_color
+  end
+
+  # Resets the use of color.
+  def reset_use_color
+    @use_color = true
+  end
+
+  # Pass +false+ to turn off HighLine's EOF tracking.
+  attr_accessor :track_eof
+
+  # Returns true if HighLine is currently tracking EOF for input.
+  def track_eof?
+    !!track_eof
   end
 
   # @return [Integer] The current column setting for wrapping output.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -60,7 +60,20 @@ class HighLine
     def supports_rgb_color?
       true
     end
+
+    # Pass ColorScheme to _setting_ to set a HighLine color scheme.
+    def color_scheme=( setting )
+      @color_scheme = setting
+    end
+
+    # Returns the current color scheme.
+    def color_scheme
+      @color_scheme
+    end
   end
+
+  # The setting used to control color schemes.
+  @color_scheme = nil
 
   # Set it to false to disable ANSI coloring
   attr_writer :use_color
@@ -83,19 +96,6 @@ class HighLine
   # Returns true if HighLine is currently tracking EOF for input.
   def track_eof?
     @track_eof
-  end
-
-  # The setting used to control color schemes.
-  @color_scheme = nil
-
-  # Pass ColorScheme to _setting_ to set a HighLine color scheme.
-  def self.color_scheme=( setting )
-    @color_scheme = setting
-  end
-
-  # Returns the current color scheme.
-  def self.color_scheme
-    @color_scheme
   end
 
   # Returns +true+ if HighLine is currently using a color scheme.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -47,14 +47,17 @@ class HighLine
   extend SingleForwardable
   def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
                         :use_color=, :use_color?, :reset_use_color,
-                        :track_eof=, :track_eof?, :color, :color_code
+                        :track_eof=, :track_eof?,
+                        :color, :uncolor, :color_code
 
-  def self.default_instance
-    @default_instance
-  end
+  class << self
+    def default_instance
+      @default_instance
+    end
 
-  def self.default_instance=(highline_instance)
-    @default_instance = highline_instance
+    def default_instance=(highline_instance)
+      @default_instance = highline_instance
+    end
   end
 
   # Set it to false to disable ANSI coloring

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -47,7 +47,7 @@ class HighLine
   extend SingleForwardable
   def_single_delegators :@default_instance, :agree, :ask, :choose, :say,
                         :use_color=, :use_color?, :reset_use_color,
-                        :track_eof=, :track_eof?, :color
+                        :track_eof=, :track_eof?, :color, :color_code
 
   def self.default_instance
     @default_instance
@@ -330,15 +330,12 @@ class HighLine
   #   s.code # => "\e[31m\e[34m"
   #
   #   HighLine.color_code(:red, :blue) # => "\e[31m\e[34m"
-
-  def self.color_code(*colors)
-    Style(*colors).code
-  end
-
-  # (see HighLine.color_code)
-  # Convenience instance method. It delegates to the class method.
+  #
+  #   cli = HighLine.new
+  #   cli.color_code(:red, :blue) # => "\e[31m\e[34m"
+  #
   def color_code(*colors)
-    self.class.color_code(*colors)
+    HighLine.Style(*colors).code
   end
 
   # Remove color codes from a string.

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -48,6 +48,10 @@ class HighLine
     @default_instance ||= new
   end
 
+  def self.default_instance=(highline_instance)
+    @default_instance = highline_instance
+  end
+
   # Set it to false to disable ANSI coloring
   attr_writer :use_color
 

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -44,6 +44,10 @@ class HighLine
   include BuiltinStyles
   include CustomErrors
 
+  def self.default_instance
+    @default_instance ||= new
+  end
+
   # Set it to false to disable ANSI coloring
   attr_writer :use_color
 

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -52,6 +52,14 @@ class HighLine
 
   class << self
     attr_accessor :default_instance
+
+    # For checking if the current version of HighLine supports RGB colors
+    # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
+    # Note: color usage also depends on HighLine.use_color being set
+    # TODO: Discuss removing this method
+    def supports_rgb_color?
+      true
+    end
   end
 
   # Set it to false to disable ANSI coloring
@@ -65,13 +73,6 @@ class HighLine
   # Resets the use of color.
   def reset_use_color
     @use_color = true
-  end
-
-  # For checking if the current version of HighLine supports RGB colors
-  # Usage: HighLine.supports_rgb_color? rescue false   # rescue for compatibility with older versions
-  # Note: color usage also depends on HighLine.use_color being set
-  def self.supports_rgb_color?
-    true
   end
 
   # Pass +false+ to _setting_ to turn off HighLine's EOF tracking.

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -22,7 +22,7 @@ require "forwardable"
 #
 module Kernel
   extend Forwardable
-  def_delegators :HighLine, :agree, :ask, :choose, :say
+  def_instance_delegators :HighLine, :agree, :ask, :choose, :say
 end
 
 # When requiring 'highline/import' HighLine adds {#or_ask} to Object so

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -14,11 +14,11 @@ require "forwardable"
 # <tt>require "highline/import"</tt> adds shortcut methods to Kernel, making
 # {HighLine#agree}, {HighLine#ask}, {HighLine#choose} and {HighLine#say}
 # globally available.  This is handy for
-# quick and dirty input and output.  These methods use the HighLine object in
-# the global variable <tt>$terminal</tt>, which is initialized to use
-# <tt>$stdin</tt> and <tt>$stdout</tt> (you are free to change this).
-# Otherwise, these methods are identical to their {HighLine} counterparts, see that
-# class for detailed explanations.
+# quick and dirty input and output.  These methods use HighLine.default_instance
+# which is initialized to use <tt>$stdin</tt> and <tt>$stdout</tt> (you are free
+# to change this).
+# Otherwise, these methods are identical to their {HighLine} counterparts,
+# see that class for detailed explanations.
 #
 module Kernel
   extend Forwardable

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -22,8 +22,7 @@ require "forwardable"
 #
 module Kernel
   extend Forwardable
-  def_delegators :HighLine, :agree, :ask, :choose, :say,
-                 :use_color=, :use_color?, :reset_use_color
+  def_delegators :HighLine, :agree, :ask, :choose, :say
 end
 
 # When requiring 'highline/import' HighLine adds {#or_ask} to Object so

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -22,7 +22,7 @@ require "forwardable"
 #
 module Kernel
   extend Forwardable
-  def_delegators :$terminal, :agree, :ask, :choose, :say,
+  def_delegators :HighLine, :agree, :ask, :choose, :say,
                  :use_color=, :use_color?, :reset_use_color
 end
 

--- a/lib/highline/import.rb
+++ b/lib/highline/import.rb
@@ -10,8 +10,6 @@
 require "highline"
 require "forwardable"
 
-$terminal = HighLine.new
-
 #
 # <tt>require "highline/import"</tt> adds shortcut methods to Kernel, making
 # {HighLine#agree}, {HighLine#ask}, {HighLine#choose} and {HighLine#say}

--- a/lib/highline/simulate.rb
+++ b/lib/highline/simulate.rb
@@ -44,7 +44,7 @@ class HighLine
     end
 
     # A wrapper method that temporarily replaces the Highline
-    # instance in $terminal with an instance of this object
+    # instance in HighLine.default_instance with an instance of this object
     # for the duration of the block
     #
     # @param strings [String] preloaded string buffer that

--- a/lib/highline/simulate.rb
+++ b/lib/highline/simulate.rb
@@ -51,11 +51,11 @@ class HighLine
     #   will feed the input operations when simulating.
 
     def self.with(*strings)
-      @input = $terminal.instance_variable_get :@input
-      $terminal.instance_variable_set :@input, new(strings)
+      @input = HighLine.default_instance.instance_variable_get :@input
+      HighLine.default_instance.instance_variable_set :@input, new(strings)
       yield
     ensure
-      $terminal.instance_variable_set :@input, @input
+      HighLine.default_instance.instance_variable_set :@input, @input
     end
   end
 end

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -2,5 +2,5 @@
 
 class HighLine
   # The version of the installed library.
-  VERSION = "2.0.0-develop.9".freeze
+  VERSION = "2.0.0-develop.10".freeze
 end

--- a/test/acceptance/acceptance.rb
+++ b/test/acceptance/acceptance.rb
@@ -35,7 +35,7 @@ james@grayproductions.net
 === HighLine Acceptance Tests Report
 Date: #{Time.now.utc}
 HighLine::VERSION: #{HighLine::VERSION}
-Terminal: #{$terminal.terminal.class}
+Terminal: #{HighLine.default_instance.terminal.class}
 RUBY_DESCRIPTION: #{RUBY_DESCRIPTION rescue 'not available'}
 Readline::VERSION: #{Readline::VERSION rescue 'not availabe'}
 ENV['SHELL']: #{ENV['SHELL']}

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1606,18 +1606,18 @@ class TestHighLine < Minitest::Test
   
   def test_track_eof
     assert_raises(EOFError) { @terminal.ask("Any input left?  ") }
-    
+
     # turn EOF tracking
-    old_setting = HighLine.track_eof?
+    old_instance = HighLine.default_instance
+    HighLine.default_instance = HighLine.new(StringIO.new, StringIO.new)
     HighLine.track_eof = false
     begin
       require 'highline/import'
-      HighLine.default_instance = HighLine.new(StringIO.new, StringIO.new)
       ask("And now?  ")  # this will still blow up, nothing available
     rescue
       refute_equal(EOFError, $!.class)  # but HighLine's safe guards are off
     end
-    HighLine.track_eof = old_setting
+    HighLine.default_instance = old_instance
   end
   
   def test_version

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1612,6 +1612,7 @@ class TestHighLine < Minitest::Test
     HighLine.track_eof = false
     begin
       require 'highline/import'
+      HighLine.default_instance = HighLine.new(StringIO.new, StringIO.new)
       ask("And now?  ")  # this will still blow up, nothing available
     rescue
       refute_equal(EOFError, $!.class)  # but HighLine's safe guards are off

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -511,12 +511,12 @@ class TestHighLine < Minitest::Test
 
   def test_color_setting_per_instance
     require 'highline/import'
-    old_glob_term = $terminal
+    old_glob_instance = HighLine.default_instance
     old_setting = HighLine.use_color?
 
     gterm_input = StringIO.new
     gterm_output = StringIO.new
-    $terminal = HighLine.new(gterm_input, gterm_output)
+    HighLine.default_instance = HighLine.new(gterm_input, gterm_output)
 
     # It can set coloring at HighLine class
     cli_input = StringIO.new
@@ -600,7 +600,7 @@ class TestHighLine < Minitest::Test
 
     HighLine.use_color = old_setting
     @terminal.use_color = old_setting
-    $terminal = old_glob_term
+    HighLine.default_instance = old_glob_instance
   end
 
   def test_reset_use_color

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1611,7 +1611,8 @@ class TestHighLine < Minitest::Test
     old_setting = HighLine.track_eof?
     HighLine.track_eof = false
     begin
-      @terminal.ask("And now?  ")  # this will still blow up, nothing available
+      require 'highline/import'
+      ask("And now?  ")  # this will still blow up, nothing available
     rescue
       refute_equal(EOFError, $!.class)  # but HighLine's safe guards are off
     end

--- a/test/test_import.rb
+++ b/test/test_import.rb
@@ -20,6 +20,14 @@ class TestImport < Minitest::Test
     assert_respond_to(self, :choose)
     assert_respond_to(self, :say)
   end
+
+  def test_healthy_default_instance_after_import
+    refute_nil HighLine.default_instance
+    assert_instance_of HighLine, HighLine.default_instance
+
+    # If correctly initialized, it will contain several ins vars.
+    refute_empty HighLine.default_instance.instance_variables
+  end
   
   def test_or_ask
     old_instance = HighLine.default_instance

--- a/test/test_import.rb
+++ b/test/test_import.rb
@@ -44,12 +44,12 @@ class TestImport < Minitest::Test
   end
   
   def test_redirection
-    old_terminal = $terminal
+    old_instance = HighLine.default_instance
     
-    $terminal = HighLine.new(nil, (output = StringIO.new))
+    HighLine.default_instance = HighLine.new(nil, (output = StringIO.new))
     say("Testing...")
     assert_equal("Testing...\n", output.string)
   ensure
-    $terminal = old_terminal
+    HighLine.default_instance = old_instance
   end
 end

--- a/test/test_import.rb
+++ b/test/test_import.rb
@@ -22,11 +22,11 @@ class TestImport < Minitest::Test
   end
   
   def test_or_ask
-    old_terminal = $terminal
+    old_instance = HighLine.default_instance
     
     input     = StringIO.new
     output    = StringIO.new
-    $terminal = HighLine.new(input, output)  
+    HighLine.default_instance = HighLine.new(input, output)  
     
     input << "10\n"
     input.rewind
@@ -40,7 +40,7 @@ class TestImport < Minitest::Test
     
     assert_equal(10, 20.or_ask("How much?  ", Integer) { |q| q.in = 1..10 })
   ensure
-    $terminal = old_terminal
+    HighLine.default_instance = old_instance
   end
   
   def test_redirection

--- a/test/test_simulator.rb
+++ b/test/test_simulator.rb
@@ -7,7 +7,7 @@ class SimulatorTest < Minitest::Test
   def setup
     input     = StringIO.new
     output    = StringIO.new
-    $terminal = HighLine.new(input, output)
+    HighLine.default_instance = HighLine.new(input, output)
   end
 
   def test_simulator


### PR DESCRIPTION
To maintain minimum back compatibility we will follow these steps at the internals:
* Create a `HighLine instance` after definition of `HighLine` class
* Saves it at `HighLine.default_instance`
* Everything we have been doing with global `$terminal` now we do with `HighLine.default_instance`
* Take the opportunity to group related methods together to easier code reading

Although we're still relying on a _global state_ at least now we're namespaced on HighLine and we now avoid name collisions that have happened at the past with `$terminal` global var (as *terminal* is a very common word).
