### PR TITLE
Resolves #219 - May set response to anything that answers to :call

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
-### Unreleased
+### 2.0.0-develop.13 / 2017-11-05
+* PR #219 - Make possible to use a callable as response (@abinoam)
+
+### 2.0.0-develop.12 / 2017-10-19
 * PR #218 - Ease transition from 1.7.x to 2.0.x (@abinoam)
   * Copy use_color from HighLine.default_instance
   * Expose IOConsoleCompatible

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -479,15 +479,6 @@ class HighLine
 
   private
 
-  #
-  # A helper method for sending the output stream and error and repeat
-  # of the question.
-  #
-  def explain_error(error, question)
-    say(question.final_responses[error]) if error
-    say(question.ask_on_error_msg)
-  end
-
   # Adds a layer of scope (new_scope) to ask a question inside a
   # question, without destroying instance data
   def confirm(question)

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -289,6 +289,11 @@ class HighLine
       @internal_responses.merge(@user_responses)
     end
 
+    def final_response(error)
+      response = final_responses[error]
+      response.call(answer) rescue response
+    end
+
     #
     # Returns the provided _answer_string_ after changing character case by
     # the rules of this Question.  Valid settings for whitespace are:

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -291,7 +291,11 @@ class HighLine
 
     def final_response(error)
       response = final_responses[error]
-      response.call(answer) rescue response
+      if response.respond_to?(:call)
+        response.call(answer)
+      else
+        response
+      end
     end
 
     #

--- a/lib/highline/question_asker.rb
+++ b/lib/highline/question_asker.rb
@@ -115,8 +115,13 @@ class HighLine
 
     ## Delegate to Highline
     def explain_error(error)
-      @highline.say(question.final_responses[error]) if error
+      @highline.say(error_final_response(error)) if error
       @highline.say(question.ask_on_error_msg)
+    end
+
+    def error_final_response(error)
+      final_response = question.final_responses[error]
+      final_response.call(question.answer) rescue final_response
     end
 
     def gather_with_array

--- a/lib/highline/question_asker.rb
+++ b/lib/highline/question_asker.rb
@@ -114,14 +114,9 @@ class HighLine
     private
 
     ## Delegate to Highline
-    def explain_error(error)
-      @highline.say(error_final_response(error)) if error
+    def explain_error(explanation_key) # eg: :not_valid, :not_in_range
+      @highline.say(question.final_response(explanation_key))
       @highline.say(question.ask_on_error_msg)
-    end
-
-    def error_final_response(error)
-      final_response = question.final_responses[error]
-      final_response.call(question.answer) rescue final_response
     end
 
     def gather_with_array

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -2,5 +2,5 @@
 
 class HighLine
   # The version of the installed library.
-  VERSION = "2.0.0-develop.12".freeze
+  VERSION = "2.0.0-develop.13".freeze
 end

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1577,6 +1577,25 @@ class TestHighLine < Minitest::Test
     assert_equal("Gray, James Edward", answer)
   end
 
+  def test_validation_with_overriding_static_message
+    @input << "Not valid answer\n" \
+              "42\n"
+
+    @input.rewind
+
+    answer = @terminal.ask("Enter only numbers:  ") do |question|
+      question.validate = ->(ans) { ans =~ /\d+/ }
+      question.responses[:not_valid] = "We accept only numbers over here!"
+    end
+
+    assert_equal("42", answer)
+    assert_equal(
+      "Enter only numbers:  We accept only numbers over here!\n" \
+      "?  ",
+      @output.string
+    )
+  end
+
   def test_whitespace
     @input << "  A   lot\tof  \t  space\t  \there!   \n"
     @input.rewind

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1596,6 +1596,27 @@ class TestHighLine < Minitest::Test
     )
   end
 
+  def test_validation_with_overriding_dynamic_message
+    @input << "Forty two\n" \
+              "42\n"
+
+    @input.rewind
+
+    answer = @terminal.ask("Enter only numbers:  ") do |question|
+      question.validate = ->(ans) { ans =~ /\d+/ }
+      question.responses[:not_valid] =
+        ->(ans) { "#{ans} is not a valid answer" }
+    end
+
+    assert_equal("42", answer)
+    assert_equal(
+      "Enter only numbers:  " \
+      "Forty two is not a valid answer\n" \
+      "?  ",
+      @output.string
+    )
+  end
+
   def test_whitespace
     @input << "  A   lot\tof  \t  space\t  \there!   \n"
     @input.rewind


### PR DESCRIPTION
Resolves #219 

Now it is possible to have error responses that are dynamic created through a callable object.

```ruby
require 'highline'
cli = HighLine.new

cli.ask("Enter only numbers:  ") do |question|
  question.validate = ->(ans) { ans =~ /\d+/ }
  question.responses[:not_valid] =
    ->(ans) { "#{ans} is not a valid answer" }
end
```