### PR TITLE
Fix #221 - Consistent behaviour for agree with readline = true

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+### 2.0.0-develop.14 / 2017-11-21
+* PR #222 / I #221 - Fix inconsistent behaviour when using agree with readline (@abinoam, @ailisp)
+
 ### 2.0.0-develop.13 / 2017-11-05
 * PR #219 - Make possible to use a callable as response (@abinoam)
 

--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -196,6 +196,7 @@ class HighLine
       q.responses[:not_valid]    = 'Please enter "yes" or "no".'
       q.responses[:ask_on_error] = :question
       q.character                = character
+      q.completion               = %w[yes no]
 
       yield q if block_given?
     end

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -575,7 +575,7 @@ class HighLine
     # @param highline [HighLine] context
     # @return [void]
     def show_question(highline)
-      highline.say(self) unless readline && (echo == true && !limit)
+      highline.say(self)
     end
 
     # Returns an echo string that is adequate for this Question settings.

--- a/lib/highline/terminal.rb
+++ b/lib/highline/terminal.rb
@@ -98,9 +98,7 @@ class HighLine
     def get_line_with_readline(question, highline)
       require "readline" # load only if needed
 
-      question_string = highline.render_statement(question)
-
-      raw_answer = readline_read(question_string, question)
+      raw_answer = readline_read(question)
 
       if !raw_answer && highline.track_eof?
         raise EOFError, "The input stream is exhausted."
@@ -113,7 +111,7 @@ class HighLine
     # @param prompt [String] Readline prompt
     # @param question [HighLine::Question] question from where to get
     #   autocomplete candidate strings
-    def readline_read(prompt, question)
+    def readline_read(question)
       # prep auto-completion
       unless question.selection.empty?
         Readline.completion_proc = lambda do |str|

--- a/lib/highline/terminal.rb
+++ b/lib/highline/terminal.rb
@@ -126,7 +126,7 @@ class HighLine
       $VERBOSE    = nil
 
       raw_answer  = run_preserving_stty do
-        Readline.readline(prompt, true)
+        Readline.readline("", true)
       end
 
       $VERBOSE = old_verbose

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -2,5 +2,5 @@
 
 class HighLine
   # The version of the installed library.
-  VERSION = "2.0.0-develop.13".freeze
+  VERSION = "2.0.0-develop.14".freeze
 end

--- a/test/acceptance/at_readline_agree.rb
+++ b/test/acceptance/at_readline_agree.rb
@@ -1,0 +1,18 @@
+# coding: utf-8
+
+require_relative "acceptance_test"
+
+HighLine::AcceptanceTest.check do |t|
+  t.desc =
+    "This step checks if the readline works well with agree.\n" \
+    "You should press <tab> and readline should give the default " \
+    "(yes/no) options to autocomplete."
+
+  t.action = proc do
+    answer = agree("Do you agree?") { |q| q.readline = true }
+    puts "You've entered -> #{answer} <-"
+  end
+
+  t.question =
+    "Did HighLine#agree worked well using question.readline = true (y/n)? "
+end


### PR DESCRIPTION
Fix #221 

Dear @ailisp, could you test this branch against your code?
I think it fixes the inconsistent behaviour of agree with readline.
The trick was to use `Readline.readline` with and empty prompt.
Then we could rely on the normal prompt handling.
