### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/highline/list_renderer.rb
+++ b/lib/highline/list_renderer.rb
@@ -92,7 +92,11 @@ class HighLine
     def render_list_items(items)
       items.to_ary.map do |item|
         item = String(item)
-        template = ERB.new(item, nil, "%")
+        template = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(item, trim_mode: "%")
+        else
+          ERB.new(item, nil, "%")
+        end
         template_renderer =
           HighLine::TemplateRenderer.new(template, self, highline)
         template_renderer.render

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -548,7 +548,11 @@ class HighLine
       else
         # evaluate ERb under initial scope, so it will have
         # access to question and answer
-        template = ERB.new(confirm, nil, "%")
+        template = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(confirm, trim_mode: "%")
+        else
+          ERB.new(confirm, nil, "%")
+        end
         template_renderer = TemplateRenderer.new(template, self, highline)
         template_renderer.render
       end

--- a/lib/highline/statement.rb
+++ b/lib/highline/statement.rb
@@ -78,7 +78,11 @@ class HighLine
     end
 
     def template
-      @template ||= ERB.new(template_string, nil, "%")
+      @template ||= if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        ERB.new(template_string, trim_mode: "%")
+      else
+        ERB.new(template_string, nil, "%")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR suppresses the following warnings when using Ruby 2.6.0-dev.

```console
% be rake
/Users/koic/.rbenv/versions/2.6.0-dev/bin/ruby -w -I"lib:test"
-I"/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rake-12.3.1/lib"
"/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/rake-12.3.1/lib/rake/rake_test_loader.rb"
"test/test_answer_converter.rb" "test/test_color_scheme.rb"
"test/test_helper.rb" "test/test_highline.rb" "test/test_import.rb"
"test/test_list.rb" "test/test_menu.rb" "test/test_paginator.rb"
"test/test_question_asker.rb" "test/test_simulator.rb"
"test/test_string_extension.rb" "test/test_string_highline.rb"
"test/test_style.rb" "test/test_wrapper.rb"
Tests will be run under:
  - HighLine::Terminal::IOConsole
  - HighLine::VERSION 2.0.0-develop.15
  - ruby 2.6.0dev (2018-05-08 trunk 63359) [x86_64-darwin17]
Run options: --seed 11307

# Running:

.....................................SS..S/Users/koic/src/github.com/JEG2/highline/lib/highline/statement.rb:81:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword
arguments.
/Users/koic/src/github.com/JEG2/highline/lib/highline/statement.rb:81:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
instead.
/Users/koic/src/github.com/JEG2/highline/lib/highline/list_renderer.rb:95:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword
arguments.
/Users/koic/src/github.com/JEG2/highline/lib/highline/list_renderer.rb:95:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...)
instead.

(snip)
```

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only

This PR uses `ERB.instance_method(:initialize).parameters.assoc(:key)` to switch `ERB.new` interface. Because HighLine supports multiple Ruby versions, it need to use the appropriate interface. This approach is built into Ruby.
https://github.com/ruby/ruby/commit/3406c5d