### PR TITLE
CI: Add 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 dist: trusty
-sudo: false
 cache: bundler
 script: "bundle exec rake test"
 rvm:
@@ -29,6 +28,9 @@ matrix:
         - "gem update --system -N"
         - "gem update bundler -N"
     - rvm: 2.5
+      before_install:
+        - gem install bundler
+    - rvm: 2.6
       before_install:
         - gem install bundler
     - rvm: ruby-head


### PR DESCRIPTION
This PR adds 2.6 to the build matrix.

Also:

- Remove an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration