### PR TITLE
Suppress `Psych.safe_load` arg warn when using Psych 3.1.0+

### DIFF
--- a/test/test_string_extension.rb
+++ b/test/test_string_extension.rb
@@ -40,9 +40,11 @@ class TestStringExtension < Minitest::Test
     highline_string =
       HighLine::String.new("Yaml didn't messed with HighLine::String")
     yaml_highline_string = highline_string.to_yaml
-    yaml_loaded_string =
-      YAML.safe_load(yaml_highline_string, [HighLine::String])
-
+    yaml_loaded_string = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0') # Ruby 2.6+
+                           YAML.safe_load(yaml_highline_string, permitted_classes: [HighLine::String])
+                         else
+                           YAML.safe_load(yaml_highline_string, [HighLine::String])
+                         end
     assert_equal "Yaml didn't messed with HighLine::String",
                  yaml_loaded_string
     assert_equal highline_string, yaml_loaded_string


### PR DESCRIPTION
This PR suppresses the following `Psych.safe_load` args warn when using Psych 3.1.0 (Ruby 2.6+).

```console
% ruby -v
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin17]
% bundle exec rake
(snip)

/Users/koic/src/github.com/JEG2/highline/test/test_string_extension.rb:44:
Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated.
Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.
```