### PR TITLE
Avoid using the last argument as keyword parameter

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -621,7 +621,7 @@ class HighLine
     statement = format_statement(statement)
     return unless statement.length > 0
 
-    out = (indentation+statement).encode(Encoding.default_external, { :undef => :replace  } )
+    out = (indentation+statement).encode(Encoding.default_external, undef: :replace)
 
     # Don't add a newline if statement ends with whitespace, OR
     # if statement ends with whitespace before a color escape code.


### PR DESCRIPTION
This fixes the following warning when running the code with Ruby 2.7:

```text
gems/highline-1.7.10/lib/highline.rb:624: warning: Using the last argument as keyword parameters is deprecated
```

Fastlane is still using the 1.x version of this library, and this warning is printed as soon as it's launched. It think it would be great if this could be released as a patch release (e.g. `1.7.11`) so that the warning is no longer printed:

<img width="1109" alt="Screenshot 2021-04-14 at 14 14 24" src="https://user-images.githubusercontent.com/189580/114708509-b9207a00-9d2b-11eb-9090-1fd034d6b74a.png">
