### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -21,7 +22,7 @@ jobs:
           - jruby-9.3
           - jruby-9.2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :code_quality do
   gem "flog", require: false
   gem "pronto", require: false, platform: :ruby
   gem "pronto-flay", require: false, platform: :ruby
-  gem "pronto-poper", require: false, platform: :ruby
   gem "pronto-reek", require: false, platform: :ruby
   gem "pronto-rubocop", require: false, platform: :ruby
 end


### PR DESCRIPTION
Also updates the checkout action to v3.

To get this to run green I had to remove the `pronto-poper` dependency.  `poper` no longer appears to be actively maintained, and it's a gem for checking formatting of commit messages, so I thought this was a sensible tradeoff.

With this change, runs green on my fork.

cc: @abinoam 