### PR TITLE
Issue #246 - Add custom validation class option to `Question#validate`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,11 @@
 Below is a complete listing of changes for each revision of HighLine.
 
 ### Unreleased 2.2.0.develop.1
-* I #233 Show Question#default hint for non String values (@abinoam)
+* PR #258 / I #246 - Add validation class support
+  * Make it dry-types compatible through the use of `#valid?`
+  * Solve the multiple answers in one line problem with a combination of
+    custom coercion (parser) and custom validation
+* PR #257 / I #233 - Show Question#default hint for non String values (@abinoam)
   * Add Question#default_hint_show to allow disabling it.
 
 ### 2.1.0 / 2022-12-31

--- a/README.md
+++ b/README.md
@@ -58,6 +58,33 @@ end
 cli.ask("Age?  ", Integer) { |q| q.in = 0..105 }
 cli.ask("Name?  (last, first)  ") { |q| q.validate = /\A\w+, ?\w+\Z/ }
 
+## Validation with custom class
+class ZeroToTwentyFourValidator
+  def self.valid?(answer)
+    (0..24).include? answer.to_i
+  end
+
+  def self.inspect
+    "(0..24) rule"
+  end
+end
+
+cli.ask("What hour of the day is it?:  ", Integer) do |q|
+  q.validate = ZeroToTwentyFourValidator
+end
+
+## Validation with Dry::Types
+## `Dry::Types` provides a `valid?` method so it can be used effortlessly
+
+require 'dry-type'
+
+module Types
+  include Dry.Types
+end
+
+cli.ask("Type an integer:", Integer) do |q|
+  q.validate = Types::Coercible::Integer
+end
 
 # Type conversion for answers:
 

--- a/examples/custom_parser_custom_validator.rb
+++ b/examples/custom_parser_custom_validator.rb
@@ -1,0 +1,39 @@
+require 'highline'
+
+cli = HighLine.new
+
+# The parser
+class ArrayOfNumbersFromString
+  def self.parse(string)
+    string.scan(/\d+/).map(&:to_i)
+  end
+end
+
+# The validator
+class ArrayOfNumbersFromStringInRange
+  def self.in?(range)
+    new(range)
+  end
+
+  attr_reader :range
+
+  def initialize(range)
+    @range = range
+  end
+
+  def valid?(answer)
+    ary = ArrayOfNumbersFromString.parse(answer)
+    ary.all? ->(number) { range.include? number }
+  end
+
+  def inspect
+    "in range #@range validator"
+  end
+end
+
+answer = cli.ask("Which number? (0 or <Enter> to skip): ", ArrayOfNumbersFromString) { |q|
+  q.validate = ArrayOfNumbersFromStringInRange.in?(0..10)
+  q.default = 0
+}
+
+puts "Your answer was: #{answer} and it was correctly validated and coerced into an #{answer.class}"

--- a/highline.gemspec
+++ b/highline.gemspec
@@ -32,4 +32,5 @@ DESCRIPTION
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "dry-types"
 end

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -145,6 +145,9 @@ class HighLine
     # If set to a Regexp, the answer must match (before type conversion).
     # Can also be set to a Proc which will be called with the provided
     # answer to validate with a +true+ or +false+ return.
+    # It's possible to use a custom validator class. It must respond to
+    # `#valid?`. The result of `#inspect` will be used in error messages.
+    # See README.md for details.
     #
     attr_accessor :validate
     # Used to control range checks for answer.

--- a/lib/highline/question.rb
+++ b/lib/highline/question.rb
@@ -502,7 +502,8 @@ class HighLine
     def valid_answer?
       !validate ||
         (validate.is_a?(Regexp) && answer =~ validate) ||
-        (validate.is_a?(Proc)   && validate[answer])
+        (validate.is_a?(Proc)   && validate[answer]) ||
+        (validate.respond_to?(:valid?) && validate.valid?(answer))
     end
 
     #


### PR DESCRIPTION
Fix #246

Implement multiple answers in one line (one ask) by using a combination of a custom parser (already possible in previous HighLine version) and a custom validation (possible from this PR on).

As a bonus point this PR makes it possible to use `Dry::Types` (https://github.com/dry-rb/dry-types) as custom validation class because we followed their convention of `#valid?` method.

Added an example at https://github.com/JEG2/highline/blob/master/examples/custom_parser_custom_validator.rb

```ruby
require 'highline'

cli = HighLine.new

# The parser
class ArrayOfNumbersFromString
  def self.parse(string)
    string.scan(/\d+/).map(&:to_i)
  end
end

# The validator
class ArrayOfNumbersFromStringInRange
  def self.in?(range)
    new(range)
  end

  attr_reader :range

  def initialize(range)
    @range = range
  end

  def valid?(answer)
    ary = ArrayOfNumbersFromString.parse(answer)
    ary.all? ->(number) { range.include? number }
  end

  def inspect
    "in range #@range validator"
  end
end

answer = cli.ask("Which number? (0 or <Enter> to skip): ", ArrayOfNumbersFromString) { |q|
  q.validate = ArrayOfNumbersFromStringInRange.in?(0..10)
  q.default = 0
}

puts "Your answer was: #{answer} and it was correctly validated and coerced into an #{answer.class}"
```