### PR TITLE
Handle Ctrl-C when Question#echo = false (raw_no_echo_mode)

### DIFF
--- a/lib/highline.rb
+++ b/lib/highline.rb
@@ -538,6 +538,7 @@ class HighLine
     terminal.raw_no_echo_mode_exec do
       loop do
         character = terminal.get_character
+        raise Interrupt if character == "\u0003"
         break unless character
         break if ["\n", "\r"].include? character
 

--- a/lib/highline/io_console_compatible.rb
+++ b/lib/highline/io_console_compatible.rb
@@ -13,7 +13,7 @@ require "tempfile"
 #
 
 module IOConsoleCompatible
-  def getch
+  def getch(min:nil, time:nil, intr: nil)
     getc
   end
 

--- a/lib/highline/terminal/io_console.rb
+++ b/lib/highline/terminal/io_console.rb
@@ -27,7 +27,7 @@ class HighLine
 
       # (see Terminal#get_character)
       def get_character
-        input.getch # from ruby io/console
+        input.getch(intr: true) # from ruby io/console
       rescue Errno::ENOTTY
         input.getc
       end

--- a/test/test_highline.rb
+++ b/test/test_highline.rb
@@ -1300,6 +1300,20 @@ class TestHighLine < Minitest::Test
     assert_equal("maçã", answer)
   end
 
+  def test_echo_false_with_ctrl_c_interrupts
+    @input << "String with a ctrl-c at the end \u0003 \n"
+    @input.rewind
+    @answer = nil
+
+    assert_raises(Interrupt) do
+      @answer = @terminal.ask("Type:  ") do |q|
+        q.echo = false
+      end
+    end
+
+    assert_nil @answer
+  end
+
   def test_range_requirements
     @input << "112\n-541\n28\n"
     @input.rewind


### PR DESCRIPTION
Fix #236

Hi @Fahhetah,

I've set the author's commit to your e-mail to honor your suggestion.
But I've changed `exit 130` to `raise Interrupt` so it stays in line with Ruby standard behavior when receiving ctrl-C.
I'll not merge it yet as I'm investigating a little further if I could have a better more complete approach.
Because treating all ctrl codes one by one seems not a good way for the long run.

cc: @Faheetah @Thalagyrt @aspyct