### PR TITLE
Do not call stty on non-tty

### DIFF
--- a/lib/highline/terminal.rb
+++ b/lib/highline/terminal.rb
@@ -176,7 +176,7 @@ class HighLine
     # Saves terminal state using shell stty command.
     def save_stty
       @stty_save = begin
-                     `stty -g`.chomp
+                     `stty -g`.chomp if input.tty?
                    rescue StandardError
                      nil
                    end

--- a/lib/highline/terminal/unix_stty.rb
+++ b/lib/highline/terminal/unix_stty.rb
@@ -20,7 +20,9 @@ class HighLine
         rescue LoadError
         end
 
-        if /solaris/ =~ RUBY_PLATFORM &&
+        if !@output.tty?
+          [80, 24]
+        elsif /solaris/ =~ RUBY_PLATFORM &&
            `stty` =~ /\brows = (\d+).*\bcolumns = (\d+)/
           [Regexp.last_match(2), Regexp.last_match(1)].map(&:to_i)
         elsif `stty size` =~ /^(\d+)\s(\d+)$/
@@ -33,7 +35,7 @@ class HighLine
       # (see Terminal#raw_no_echo_mode)
       def raw_no_echo_mode
         save_stty 
-        system "stty raw -echo -icanon isig"
+        system "stty raw -echo -icanon isig" if input.tty?
       end
 
       # (see Terminal#restore_mode)

--- a/lib/highline/terminal/unix_stty.rb
+++ b/lib/highline/terminal/unix_stty.rb
@@ -32,13 +32,13 @@ class HighLine
 
       # (see Terminal#raw_no_echo_mode)
       def raw_no_echo_mode
-        @state = `stty -g`
+        save_stty 
         system "stty raw -echo -icanon isig"
       end
 
       # (see Terminal#restore_mode)
       def restore_mode
-        system "stty #{@state}"
+        restore_stty
         print "\r"
       end
 


### PR DESCRIPTION
Thanks for this great project

## Before

Both of these cause a warning:

```ruby
input.echo = true
ask("question", "y") { |q| q.readline = true }
```

The warning:

```bash
echo | rake | cat

......stty: stdin isn't a terminal......
```

## Solution

It no longer calls `stty` for a non-tty. The reasoning being that if you do call `stty`, then it will just throw an error and skip the `stty` call in the first place. So why call it?

This is following the precedence for the terminal size portion that checked `@output.tty?`
There are other cases that call the stty methods and catch errors, but those cases have a request to fix them.

It looks like many of these use cases are not under test.
Please let me know what I can do to help you feel comfortable with these changes