### PR TITLE
Add abbrev gem as dependency

### DIFF
--- a/highline.gemspec
+++ b/highline.gemspec
@@ -29,6 +29,7 @@ DESCRIPTION
 
   spec.required_ruby_version = ">= 3.0"
 
+  spec.add_runtime_dependency "abbrev"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
abbrev has been bundled as a gem, and will be removed from the stdlib from ruby 3.4.0

under 3.3.0, this will remove this warning

> warning: abbrev was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec. Also contact author of highline-2.1.0 to add abbrev into its gemspec.