### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/highline

### DIFF
--- a/highline.gemspec
+++ b/highline.gemspec
@@ -34,4 +34,6 @@ DESCRIPTION
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "dry-types"
   spec.add_development_dependency "reline"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/Changelog.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/highline which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/