### PR TITLE
Fix #271 - Readline completely deprecated in Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             ruby-version: '3.3'
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 Below is a complete listing of changes for each revision of HighLine.
 
+### 3.1.0 / 2024-07-15
+* PR #272 / I #271 - Readline is now completed deprecated over Reline (@abinoam, issue by @64kramsystem)
+* PR #269 - Provide a 'Changelog' link on rubygems.org/gems/highline (@mark-young-atg)
+
 ### 3.0.1 / 2024-01-20
 * PR #268 - Remove unused abbrev dependency (@zvkemp)
 

--- a/highline.gemspec
+++ b/highline.gemspec
@@ -33,7 +33,8 @@ DESCRIPTION
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "dry-types"
-  spec.add_development_dependency "reline"
+
+  spec.add_runtime_dependency "reline"
 
   spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/Changelog.md"
 end

--- a/lib/highline/terminal.rb
+++ b/lib/highline/terminal.rb
@@ -112,7 +112,7 @@ class HighLine
     def readline_read(question, highline)
       # prep auto-completion
       unless question.selection.empty?
-        Readline.completion_proc = lambda do |str|
+        Reline.completion_proc = lambda do |str|
           question.selection.grep(/\A#{Regexp.escape(str)}/)
         end
       end
@@ -124,7 +124,7 @@ class HighLine
 
       raw_answer  = run_preserving_stty do
         prompt = highline.render_and_ident_statement(question)
-        Readline.readline(prompt, true)
+        Reline.readline(prompt, true)
       end
 
       $VERBOSE = old_verbose

--- a/lib/highline/version.rb
+++ b/lib/highline/version.rb
@@ -2,5 +2,5 @@
 
 class HighLine
   # The version of the installed library.
-  VERSION = "3.0.1".freeze
+  VERSION = "3.1.0".freeze
 end

--- a/test/acceptance/at_readline.rb
+++ b/test/acceptance/at_readline.rb
@@ -17,7 +17,7 @@ HighLine::AcceptanceTest.check do |t|
     "that begins with the 'l' letter in this particular case.\n\n" \
     "If I don't type any character but press <TAB> two times, I should\n" \
     "be able to see ALL available options.\n\n" \
-    "Please, play with Readline autocomplete for a while, pressing <ENTER>\n" \
+    "Please, play with Reline autocomplete for a while, pressing <ENTER>\n" \
     "to see that it really gets the selected answer.\n" \
     "When ready, just type 'exit' and the loop will finish.\n\n" \
     "Don't forget to answer 'y' (yes) or 'n' (no) to the question at the end."
@@ -33,5 +33,5 @@ HighLine::AcceptanceTest.check do |t|
     end
   end
 
-  t.question = "Did the Readline autocomplete work fine (y/n)? "
+  t.question = "Did the Reline autocomplete work fine (y/n)? "
 end


### PR DESCRIPTION
Fix #271