### PR TITLE
Fix Ruby software license URL in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 = License Terms
 
 Distributed under the user's choice of the {GPL Version 2}[http://www.gnu.org/licenses/old-licenses/gpl-2.0.html] (see COPYING for details) or the
-{Ruby software license}[http://www.ruby-lang.org/en/LICENSE.txt] by
+{Ruby software license}[https://www.ruby-lang.org/en/about/license.txt] by
 James Edward Gray II and Greg Brown.
 
 Please email James[mailto:james@grayproductions.net] with any questions.


### PR DESCRIPTION
Updated Ruby software license link to the correct URL.